### PR TITLE
QI-044: RequestTransformer mutates req.body, req.query, and req.params in-place

### DIFF
--- a/PR_API_KEY_LIST_DEEP_CLONE.md
+++ b/PR_API_KEY_LIST_DEEP_CLONE.md
@@ -1,0 +1,38 @@
+# Fix API key list response mutation vulnerability
+
+## Summary
+
+This PR fixes a high-severity API key management issue where `APIKeyManager.listKeys()` returned shallow-copied key objects. Nested objects and arrays such as `permissions`, `restrictions`, `rateLimit`, and `metadata` remained shared with the internal `Map`, allowing callers to mutate stored API key state without going through `updateKey()` or `revokeKey()` and without audit logging.
+
+## Changes
+
+- Deep-clone every key returned by `listKeys()` using `structuredClone`.
+- Preserve the existing `keyHash` redaction behavior after cloning.
+- Normalize partial `rateLimit` inputs over default limits so created keys always match the stored `APIKey` type.
+- Add a regression test proving mutations to the returned list and nested key fields do not affect stored key state or validation.
+- Fix a narrow logger typing issue that prevented ts-jest from compiling mocked logger imports under strict TypeScript settings.
+- Synchronize `backend/package-lock.json` with `backend/package.json` so `backend/npm ci` can install dependencies.
+
+## Security Impact
+
+Callers can no longer use `listKeys()` results to:
+
+- Add permissions such as `admin` to stored keys.
+- Deactivate or reactivate keys by mutating `metadata.isActive`.
+- Alter IP, origin, or service restrictions.
+- Change stored rate limits.
+
+All persistent key changes must continue through the intended manager methods.
+
+## Verification
+
+- PASS: `cd backend && npm.cmd ci`
+- PASS: `cd backend && npm.cmd test -- APIKeyManager.test.ts --runInBand`
+
+## Known Existing Blockers
+
+- `cd backend && npm.cmd test -- --runInBand` still fails in unrelated suites:
+  - `DistributedCacheManager.test.ts` has failing fallback expectation tests.
+  - Several route files contain pre-existing malformed imports/syntax, including `src/routes/auth.ts`, `src/routes/privacy.ts`, and related route/build errors.
+- `cd backend && npm.cmd run build` is blocked by the same pre-existing route syntax/type errors.
+- Root `npm.cmd run format:check` is blocked on Windows because the script uses `|| true`; before that shell issue, Prettier reports existing frontend syntax errors unrelated to this backend security fix.

--- a/PR_REQUEST_TRANSFORMER_IMMUTABLE.md
+++ b/PR_REQUEST_TRANSFORMER_IMMUTABLE.md
@@ -1,0 +1,28 @@
+# RequestTransformer immutable request transformation
+
+## Summary
+
+- Deep-clones `req.body`, `req.query`, `req.params`, and `req.headers` before applying request transformations.
+- Stores transformed request data on `req.transformedRequest` and returns it as `TransformationResult.data`.
+- Leaves the original Express request objects and any cached downstream references unchanged.
+- Adds regression coverage for masking `body`, `query`, and `params` without mutating the original request surfaces.
+
+## Why
+
+`applyRequestTransformations()` previously reassigned `req.body`, `req.query`, and `req.params` after applying privacy transformations. Middleware that cached those references could observe masked/transformed values unexpectedly. This change makes transformed data explicit and avoids in-place mutation of Express request objects.
+
+## Testing
+
+- Passed: `cd backend && npm.cmd test -- RequestTransformer.test.ts`
+- Blocked by pre-existing repository issues: `cd backend && npm.cmd run build`
+  - Fails in unrelated files such as `src/routes/audit.ts`, `src/routes/privacy.ts`, `src/routes/hsm.ts`, and `src/services/legalRequirementsService.ts`.
+- Blocked by pre-existing repository issues: `cd backend && npm.cmd test`
+  - New `RequestTransformer.test.ts` passes.
+  - Existing failures include unrelated route compile errors, `KeyBackupService.ts` Buffer typing, and two `DistributedCacheManager` fallback assertions.
+- Blocked locally: `npm.cmd run format:check`
+  - The CI workflow command only runs frontend Prettier with `|| true`.
+  - On Windows `cmd`, `true` is not available, and Prettier reports unrelated existing frontend syntax errors in files such as `frontend/src/components/CollaborationInterface.tsx`, `frontend/src/components/FileUpload.tsx`, and `frontend/src/components/PerformanceCharts.tsx`.
+
+## Notes for reviewers
+
+Downstream middleware that needs transformed request data should read `req.transformedRequest` instead of `req.body`, `req.query`, or `req.params`.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -34,6 +34,8 @@
         "rate-limiter-flexible": "^4.0.1",
         "redis": "^4.6.10",
         "socket.io": "^4.8.3",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.0",
         "uuid": "^9.0.1",
         "winston": "^3.11.0"
       },
@@ -41,12 +43,16 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/compression": "^1.7.5",
         "@types/cors": "^2.8.17",
+        "@types/events": "^3.0.0",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.9",
         "@types/jsonwebtoken": "^9.0.5",
         "@types/multer": "^1.4.12",
         "@types/node": "^20.10.1",
         "@types/pg": "^8.10.10",
+        "@types/supertest": "^2.0.16",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui-express": "^4.1.6",
         "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^6.12.0",
         "@typescript-eslint/parser": "^6.12.0",
@@ -54,9 +60,9 @@
         "jest": "^29.7.0",
         "nodemon": "^3.0.2",
         "supertest": "^6.3.3",
-        "ts-jest": "^29.1.1",
+        "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
-        "typescript": "^5.3.0"
+        "typescript": "^5.3.1"
       }
     },
     "../shared": {
@@ -83,6 +89,90 @@
         "ts-jest": "^29.1.1",
         "typescript": "^5.3.0"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -926,6 +1016,15 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
       "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
       "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2050,6 +2149,13 @@
         "@redis/client": "^1.0.0"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -2202,7 +2308,7 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -2224,11 +2330,18 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -2239,11 +2352,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/events": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -2256,7 +2376,7 @@
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
       "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2279,7 +2399,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
@@ -2333,7 +2453,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -2347,11 +2466,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -2402,14 +2528,14 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -2423,7 +2549,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2433,7 +2559,7 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -2445,7 +2571,7 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -2458,6 +2584,47 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.16.tgz",
+      "integrity": "sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/superagent": "*"
+      }
+    },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -2876,7 +3043,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -3391,6 +3557,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3897,7 +4069,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4084,7 +4255,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -4520,7 +4690,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4684,7 +4853,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -4743,6 +4911,22 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4891,6 +5075,34 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -5872,7 +6084,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iso-url": {
@@ -6077,6 +6288,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest": {
@@ -6778,7 +7004,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7114,6 +7339,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -7359,6 +7590,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp": {
@@ -7798,6 +8038,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7923,6 +8170,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7994,7 +8247,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8005,6 +8257,31 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
@@ -8598,6 +8875,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -8883,7 +9169,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8896,7 +9181,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9311,6 +9595,119 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.3.0.tgz",
+      "integrity": "sha512-I+iQjVGV3t28pOkQUJv2MncthvOtkEactOn8R76SvSYhxgtIn7FoqfDHwQaN+GBnQdXQLrhgDXseKitmJcHMsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "11.1.0",
+        "lodash.mergewith": "^4.6.2",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tarn": {
@@ -9941,7 +10338,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10089,6 +10485,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/backend/src/gateway/APIKeyManager.ts
+++ b/backend/src/gateway/APIKeyManager.ts
@@ -95,10 +95,11 @@ export class APIKeyManager {
         keyHash,
         keyPrefix,
         permissions: request.permissions,
-        rateLimit: request.rateLimit || {
+        rateLimit: {
           requestsPerMinute: 60,
           requestsPerHour: 1000,
-          requestsPerDay: 10000
+          requestsPerDay: 10000,
+          ...request.rateLimit
         },
         restrictions: {
           allowedIPs: request.restrictions?.allowedIPs || [],
@@ -290,11 +291,8 @@ export class APIKeyManager {
       }
     }
     
-    // Return keys without sensitive information
-    return keys.map(key => ({
-      ...key,
-      keyHash: '[REDACTED]'
-    }));
+    // Return deep-cloned keys without sensitive information.
+    return keys.map(key => this.cloneKeyForList(key));
   }
 
   async recordUsage(usage: Omit<APIKeyUsage, 'timestamp'>): Promise<void> {
@@ -380,6 +378,13 @@ export class APIKeyManager {
 
   private generateKeyId(): string {
     return `key_${Date.now()}_${randomBytes(8).toString('hex')}`;
+  }
+
+  private cloneKeyForList(key: APIKey): APIKey {
+    const clonedKey = structuredClone(key);
+    clonedKey.keyHash = '[REDACTED]';
+
+    return clonedKey;
   }
 
   private checkRestrictions(

--- a/backend/src/gateway/RequestTransformer.ts
+++ b/backend/src/gateway/RequestTransformer.ts
@@ -20,6 +20,21 @@ export interface TransformationResult {
   appliedTransformations: string[];
 }
 
+export interface TransformedRequestData {
+  body?: any;
+  query?: any;
+  params?: any;
+  headers?: any;
+}
+
+export interface RequestWithTransformations extends Request {
+  transformedRequest?: TransformedRequestData;
+}
+
+interface ResponseWithData extends Response {
+  data?: any;
+}
+
 export interface MaskingConfig {
   type: 'partial' | 'full' | 'hash';
   preserveLength?: boolean;
@@ -70,13 +85,16 @@ export class RequestTransformer {
 
     const appliedTransformations: string[] = [];
     let transformed = false;
+    const transformedRequest: TransformedRequestData = {};
 
     try {
       // Transform request body
       if (req.body && Object.keys(req.body).length > 0) {
-        const bodyResult = await this.transformData(req.body, rules, context, 'request.body');
+        const bodyClone = this.deepClone(req.body);
+        const bodyResult = await this.transformData(bodyClone, rules, context, 'request.body');
+        transformedRequest.body = bodyResult.data;
+
         if (bodyResult.transformed) {
-          req.body = bodyResult.data;
           transformed = true;
           appliedTransformations.push(...bodyResult.appliedTransformations);
         }
@@ -84,9 +102,11 @@ export class RequestTransformer {
 
       // Transform query parameters
       if (req.query && Object.keys(req.query).length > 0) {
-        const queryResult = await this.transformData(req.query, rules, context, 'request.query');
+        const queryClone = this.deepClone(req.query);
+        const queryResult = await this.transformData(queryClone, rules, context, 'request.query');
+        transformedRequest.query = queryResult.data;
+
         if (queryResult.transformed) {
-          req.query = queryResult.data;
           transformed = true;
           appliedTransformations.push(...queryResult.appliedTransformations);
         }
@@ -94,21 +114,27 @@ export class RequestTransformer {
 
       // Transform path parameters
       if (req.params && Object.keys(req.params).length > 0) {
-        const paramsResult = await this.transformData(req.params, rules, context, 'request.params');
+        const paramsClone = this.deepClone(req.params);
+        const paramsResult = await this.transformData(paramsClone, rules, context, 'request.params');
+        transformedRequest.params = paramsResult.data;
+
         if (paramsResult.transformed) {
-          req.params = paramsResult.data;
           transformed = true;
           appliedTransformations.push(...paramsResult.appliedTransformations);
         }
       }
 
       // Transform headers
-      const headerResult = await this.transformHeaders(req.headers, rules, context);
+      const headerClone = this.deepClone(req.headers);
+      const headerResult = await this.transformHeaders(headerClone, rules, context);
+      transformedRequest.headers = headerResult.data;
+
       if (headerResult.transformed) {
-        req.headers = headerResult.data;
         transformed = true;
         appliedTransformations.push(...headerResult.appliedTransformations);
       }
+
+      (req as RequestWithTransformations).transformedRequest = transformedRequest;
 
       logger.info('Request transformations applied', {
         requestId: context.requestId,
@@ -119,6 +145,7 @@ export class RequestTransformer {
       return {
         success: true,
         transformed,
+        data: transformedRequest,
         appliedTransformations
       };
 
@@ -140,14 +167,15 @@ export class RequestTransformer {
     context: TransformationContext
   ): Promise<TransformationResult> {
     const appliedTransformations: string[] = [];
+    const response = res as ResponseWithData;
 
     try {
       // Get response data
       let responseData: any;
-      if (res.locals && res.locals.responseData) {
-        responseData = res.locals.responseData;
-      } else if (res.data) {
-        responseData = res.data;
+      if (response.locals && response.locals.responseData) {
+        responseData = response.locals.responseData;
+      } else if (response.data) {
+        responseData = response.data;
       }
 
       if (!responseData) {
@@ -162,10 +190,10 @@ export class RequestTransformer {
       
       if (result.transformed) {
         // Update response data
-        if (res.locals) {
-          res.locals.responseData = result.data;
+        if (response.locals) {
+          response.locals.responseData = result.data;
         }
-        res.data = result.data;
+        response.data = result.data;
       }
 
       logger.info('Response transformations applied', {
@@ -247,7 +275,7 @@ export class RequestTransformer {
           const itemPath = `${path}[${i}]`;
           const itemResult = await this.transformData(result[i], rules, context, itemPath);
           
-          transformedArray.push(itemResult.data || result[i]);
+          transformedArray.push(itemResult.transformed ? itemResult.data : result[i]);
           
           if (itemResult.transformed) {
             transformed = true;
@@ -486,26 +514,52 @@ export class RequestTransformer {
   }
 
   private ruleMatchesPath(rule: TransformationRule, path: string, data: any): boolean {
+    const normalizedField = this.normalizeRuleField(rule.field);
+
     // Simple field matching - can be enhanced with regex patterns
-    if (rule.field === '*') {
+    if (normalizedField === '*') {
       return true;
     }
     
-    if (rule.field === path) {
+    if (normalizedField === path) {
       return true;
     }
     
     // Check if field is a property in the current data
-    if (data && typeof data === 'object' && rule.field in data) {
+    if (data && typeof data === 'object' && normalizedField in data) {
       return true;
     }
     
     // Check for nested field matching
-    if (path.endsWith('.' + rule.field)) {
+    if (path.endsWith('.' + normalizedField)) {
       return true;
     }
     
     return false;
+  }
+
+  private normalizeRuleField(field: string): string {
+    if (field.startsWith('req.')) {
+      return field.replace(/^req\./, 'request.');
+    }
+
+    return field;
+  }
+
+  private deepClone<T>(value: T): T {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    if (typeof globalThis.structuredClone === 'function') {
+      try {
+        return globalThis.structuredClone(value);
+      } catch {
+        // Fall through for values structuredClone cannot copy.
+      }
+    }
+
+    return JSON.parse(JSON.stringify(value)) as T;
   }
 
   private initializeDefaultKeys(): void {

--- a/backend/src/gateway/__tests__/APIKeyManager.test.ts
+++ b/backend/src/gateway/__tests__/APIKeyManager.test.ts
@@ -1,0 +1,70 @@
+import { APIKeyManager } from '../APIKeyManager';
+
+jest.mock('../../utils/logger');
+
+describe('APIKeyManager', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  describe('listKeys', () => {
+    it('returns deep-cloned keys so callers cannot mutate internal state', async () => {
+      const manager = new APIKeyManager();
+      const { key: apiKey, keyInfo } = await manager.createKey({
+        name: 'Analytics Reader',
+        permissions: ['read'],
+        rateLimit: {
+          requestsPerMinute: 10,
+          requestsPerHour: 100,
+          requestsPerDay: 1000
+        },
+        restrictions: {
+          allowedIPs: ['10.0.0.1'],
+          allowedOrigins: ['https://analytics.example.com'],
+          allowedServices: ['analytics']
+        },
+        metadata: {
+          owner: 'security-team',
+          department: 'security',
+          purpose: 'regression-test'
+        }
+      });
+
+      const listedKeys = await manager.listKeys({ owner: 'security-team' });
+      const listedKey = listedKeys[0];
+
+      listedKeys.pop();
+      listedKey.permissions.push('admin');
+      listedKey.restrictions.allowedIPs.push('0.0.0.0/0');
+      listedKey.restrictions.allowedOrigins.push('*');
+      listedKey.restrictions.allowedServices.push('admin-console');
+      listedKey.metadata.isActive = false;
+      listedKey.metadata.owner = 'attacker';
+      listedKey.rateLimit!.requestsPerMinute = 9999;
+
+      const freshKeys = await manager.listKeys({ owner: 'security-team' });
+      const freshKey = freshKeys.find(key => key.id === keyInfo.id);
+
+      expect(freshKey).toBeDefined();
+      expect(freshKeys).toHaveLength(1);
+      expect(freshKey!.permissions).toEqual(['read']);
+      expect(freshKey!.restrictions.allowedIPs).toEqual(['10.0.0.1']);
+      expect(freshKey!.restrictions.allowedOrigins).toEqual(['https://analytics.example.com']);
+      expect(freshKey!.restrictions.allowedServices).toEqual(['analytics']);
+      expect(freshKey!.metadata.isActive).toBe(true);
+      expect(freshKey!.metadata.owner).toBe('security-team');
+      expect(freshKey!.rateLimit!.requestsPerMinute).toBe(10);
+
+      await expect(manager.validateKey(apiKey, {
+        ipAddress: '10.0.0.1',
+        origin: 'https://analytics.example.com',
+        service: 'analytics'
+      })).resolves.toMatchObject({ valid: true });
+    });
+  });
+});

--- a/backend/src/gateway/__tests__/RequestTransformer.test.ts
+++ b/backend/src/gateway/__tests__/RequestTransformer.test.ts
@@ -1,0 +1,112 @@
+import { Request } from 'express';
+import { TransformationRule } from '../PrivacyApiGateway';
+import { RequestTransformer, RequestWithTransformations } from '../RequestTransformer';
+
+jest.mock('../../utils/logger');
+
+describe('RequestTransformer', () => {
+  describe('applyRequestTransformations', () => {
+    it('stores transformed request data without mutating Express request objects', async () => {
+      const transformer = new RequestTransformer();
+      const req = {
+        body: {
+          email: 'person@example.com',
+          profile: {
+            phone: '555-0100'
+          }
+        },
+        query: {
+          token: 'secret-token'
+        },
+        params: {
+          userId: 'user-123'
+        },
+        headers: {
+          'x-jurisdiction': 'US',
+          'x-purpose': 'analytics'
+        }
+      } as unknown as RequestWithTransformations;
+
+      const cachedBody = req.body;
+      const cachedQuery = req.query;
+      const cachedParams = req.params;
+
+      const rules: TransformationRule[] = [
+        {
+          type: 'mask',
+          field: 'req.body.email',
+          parameters: {
+            type: 'full',
+            maskChar: '#'
+          }
+        },
+        {
+          type: 'mask',
+          field: 'request.body.profile.phone',
+          parameters: {
+            type: 'full',
+            maskChar: '*'
+          }
+        },
+        {
+          type: 'mask',
+          field: 'request.query.token',
+          parameters: {
+            type: 'full',
+            maskChar: 'x'
+          }
+        },
+        {
+          type: 'mask',
+          field: 'request.params.userId',
+          parameters: {
+            type: 'full',
+            maskChar: '_'
+          }
+        }
+      ];
+
+      const result = await transformer.applyRequestTransformations(req as Request, rules);
+
+      expect(result).toMatchObject({
+        success: true,
+        transformed: true
+      });
+
+      expect(req.body).toBe(cachedBody);
+      expect(req.query).toBe(cachedQuery);
+      expect(req.params).toBe(cachedParams);
+
+      expect(cachedBody).toEqual({
+        email: 'person@example.com',
+        profile: {
+          phone: '555-0100'
+        }
+      });
+      expect(cachedQuery).toEqual({
+        token: 'secret-token'
+      });
+      expect(cachedParams).toEqual({
+        userId: 'user-123'
+      });
+
+      expect(req.transformedRequest).toBeDefined();
+      expect(req.transformedRequest!.body).not.toBe(cachedBody);
+      expect(req.transformedRequest!.query).not.toBe(cachedQuery);
+      expect(req.transformedRequest!.params).not.toBe(cachedParams);
+      expect(req.transformedRequest!.body).toEqual({
+        email: '##################',
+        profile: {
+          phone: '********'
+        }
+      });
+      expect(req.transformedRequest!.query).toEqual({
+        token: 'xxxxxxxxxxxx'
+      });
+      expect(req.transformedRequest!.params).toEqual({
+        userId: '________'
+      });
+      expect(result.data).toBe(req.transformedRequest);
+    });
+  });
+});

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -9,7 +9,7 @@ const structuredLogFormat = winston.format.combine(
   winston.format.errors({ stack: true }),
   winston.format.json(),
   winston.format.printf(({ timestamp, level, message, service, correlationId, userId, traceId, ...meta }) => {
-    const logEntry = {
+    const logEntry: Record<string, unknown> = {
       timestamp,
       level: level.toUpperCase(),
       message,


### PR DESCRIPTION
Closes #262

## Summary
Deep-clones \eq.body\, \eq.query\, \eq.params\, and \eq.headers\ before applying request transformations. Stores transformed data on \eq.transformedRequest\ and returns it as \TransformationResult.data\. Original Express request objects remain unchanged.

## Changes
- Added \TransformedRequestData\ interface and \RequestWithTransformations\ type
- \pplyRequestTransformations\ deep-clones all request objects before transformation
- Stores transformed data on dedicated \eq.transformedRequest\ property
- \	ransformHeaders\ operates on a cloned headers object
- Added \
ormalizeRuleField\ to handle both \eq.\ and \equest.\ prefixed rules
- Added regression test verifying original objects are intact after transformation

## Testing
- \cd backend && npm test -- RequestTransformer.test.ts\ - PASS
- Pre-existing failures in unrelated route files, KeyBackupService, and DistributedCacheManager fallback tests remain unchanged