### PR TITLE
fix(QI-038): move declare global to separate .d.ts and make memory optional

### DIFF
--- a/frontend/src/types/performance.d.ts
+++ b/frontend/src/types/performance.d.ts
@@ -1,0 +1,15 @@
+declare global {
+  interface Performance {
+    memory?: {
+      usedJSHeapSize: number;
+      totalJSHeapSize: number;
+      jsHeapSizeLimit: number;
+    };
+  }
+
+  interface Window {
+    gc?: () => void;
+  }
+}
+
+export {};

--- a/frontend/src/utils/performanceProfiler.ts
+++ b/frontend/src/utils/performanceProfiler.ts
@@ -2,21 +2,6 @@
  * Performance profiling and optimization utilities for chart rendering
  */
 
-// Extend Performance interface to include memory API
-declare global {
-  interface Performance {
-    memory?: {
-      usedJSHeapSize: number;
-      totalJSHeapSize: number;
-      jsHeapSizeLimit: number;
-    };
-  }
-
-  interface Window {
-    gc?: () => void;
-  }
-}
-
 export interface ProfileMetrics {
   renderTime: number;
   memoryUsage: number;


### PR DESCRIPTION
## Summary

Moves the \declare global\ augmentation from \performanceProfiler.ts\ into a dedicated \rontend/src/types/performance.d.ts\ to prevent TypeScript type conflicts when other modules also augment the \Performance\ or \Window\ interfaces.

## Changes

- **Created** \rontend/src/types/performance.d.ts\ — contains the global interface augmentations for \Performance.memory\ and \Window.gc\.
- **Removed** the \declare global { ... }\ block from \rontend/src/utils/performanceProfiler.ts\.
- \performance.memory\ was already declared as optional (\memory?\) and all access sites already guard with optional chaining or \|| 0\ fallbacks, so no runtime changes were required.

## Acceptance Criteria Met

- [x] Global augmentations are moved to a global.d.ts (separate \.d.ts\).
- [x] \performance.memory\ is declared as optional in types.
- [x] Runtime checks exist alongside optional chaining.

## Definition of Done

- [x] No \declare global\ inside implementation files.
- [x] TypeScript compiles without conflicts when another module augments globals.

Closes #256