### PR TITLE
fix(#290, #291): add caller auth to grant/revoke/create_access_key; fix laplace_noise overflow

### DIFF
--- a/contracts/src/access_control.rs
+++ b/contracts/src/access_control.rs
@@ -179,11 +179,14 @@ impl DataSovereigntyAccessControl {
 
     pub fn grant_access(
         env: Env,
+        caller: Address,
         resource_id: BytesN<32>,
         user: Address,
         permission_type: PermissionType,
         ttl_seconds: Option<u64>,
     ) -> Result<(), AccessControlError> {
+        caller.require_auth();
+
         let resources: Map<BytesN<32>, ResourceOwner> = env
             .storage()
             .instance()
@@ -194,8 +197,7 @@ impl DataSovereigntyAccessControl {
             .get(resource_id.clone())
             .ok_or(AccessControlError::ResourceNotFound)?;
 
-        let caller = env.current_contract_address();
-        if caller != resource_owner.owner && !Self::is_authorized(&env, &resource_owner.owner) {
+        if caller != resource_owner.owner && !Self::is_authorized(&env, &caller) {
             return Err(AccessControlError::Unauthorized);
         }
 
@@ -245,9 +247,12 @@ impl DataSovereigntyAccessControl {
 
     pub fn revoke_access(
         env: Env,
+        caller: Address,
         resource_id: BytesN<32>,
         user: Address,
     ) -> Result<(), AccessControlError> {
+        caller.require_auth();
+
         let resources: Map<BytesN<32>, ResourceOwner> = env
             .storage()
             .instance()
@@ -258,8 +263,7 @@ impl DataSovereigntyAccessControl {
             .get(resource_id.clone())
             .ok_or(AccessControlError::ResourceNotFound)?;
 
-        let caller = env.current_contract_address();
-        if caller != resource_owner.owner && !Self::is_authorized(&env, &resource_owner.owner) {
+        if caller != resource_owner.owner && !Self::is_authorized(&env, &caller) {
             return Err(AccessControlError::Unauthorized);
         }
 
@@ -312,11 +316,14 @@ impl DataSovereigntyAccessControl {
 
     pub fn create_access_key(
         env: Env,
+        caller: Address,
         resource_id: BytesN<32>,
         holder: Address,
         permissions: Vec<PermissionType>,
         ttl_seconds: Option<u64>,
     ) -> Result<BytesN<32>, AccessControlError> {
+        caller.require_auth();
+
         let resources: Map<BytesN<32>, ResourceOwner> = env
             .storage()
             .instance()
@@ -327,8 +334,7 @@ impl DataSovereigntyAccessControl {
             .get(resource_id.clone())
             .ok_or(AccessControlError::ResourceNotFound)?;
 
-        let caller = env.current_contract_address();
-        if caller != resource_owner.owner && !Self::is_authorized(&env, &resource_owner.owner) {
+        if caller != resource_owner.owner && !Self::is_authorized(&env, &caller) {
             return Err(AccessControlError::Unauthorized);
         }
 

--- a/contracts/src/access_control_tests.rs
+++ b/contracts/src/access_control_tests.rs
@@ -9,6 +9,7 @@ mod tests {
     #[test]
     fn test_initialize() {
         let env = Env::default();
+        env.mock_all_auths();
         let admin = Address::generate(&env);
 
         DataSovereigntyAccessControl::initialize(env.clone(), admin.clone());
@@ -24,6 +25,7 @@ mod tests {
     #[test]
     fn test_register_resource() {
         let env = Env::default();
+        env.mock_all_auths();
         let admin = Address::generate(&env);
         let owner = Address::generate(&env);
         let resource_id = BytesN::<32>::random(&env);
@@ -45,6 +47,7 @@ mod tests {
     #[test]
     fn test_grant_and_revoke_access() {
         let env = Env::default();
+        env.mock_all_auths();
         let admin = Address::generate(&env);
         let owner = Address::generate(&env);
         let user = Address::generate(&env);
@@ -62,6 +65,7 @@ mod tests {
 
         let grant_result = DataSovereigntyAccessControl::grant_access(
             env.clone(),
+            owner.clone(),
             resource_id.clone(),
             user.clone(),
             PermissionType::Read,
@@ -81,7 +85,7 @@ mod tests {
         assert!(has_access);
 
         let revoke_result =
-            DataSovereigntyAccessControl::revoke_access(env.clone(), resource_id, user.clone());
+            DataSovereigntyAccessControl::revoke_access(env.clone(), owner.clone(), resource_id, user.clone());
 
         assert!(revoke_result.is_ok());
     }
@@ -89,6 +93,7 @@ mod tests {
     #[test]
     fn test_access_key_creation() {
         let env = Env::default();
+        env.mock_all_auths();
         let admin = Address::generate(&env);
         let owner = Address::generate(&env);
         let holder = Address::generate(&env);
@@ -109,6 +114,7 @@ mod tests {
 
         let key_id = DataSovereigntyAccessControl::create_access_key(
             env.clone(),
+            owner.clone(),
             resource_id,
             holder.clone(),
             permissions,
@@ -122,6 +128,7 @@ mod tests {
     #[test]
     fn test_permission_hierarchy() {
         let env = Env::default();
+        env.mock_all_auths();
         let admin = Address::generate(&env);
         let owner = Address::generate(&env);
         let user = Address::generate(&env);
@@ -140,6 +147,7 @@ mod tests {
         // Grant write permission
         DataSovereigntyAccessControl::grant_access(
             env.clone(),
+            owner.clone(),
             resource_id.clone(),
             user.clone(),
             PermissionType::Write,
@@ -184,6 +192,7 @@ mod tests {
     #[test]
     fn test_ttl_expiration() {
         let env = Env::default();
+        env.mock_all_auths();
         let admin = Address::generate(&env);
         let owner = Address::generate(&env);
         let user = Address::generate(&env);
@@ -202,6 +211,7 @@ mod tests {
         // Grant access with 1 second TTL
         DataSovereigntyAccessControl::grant_access(
             env.clone(),
+            owner.clone(),
             resource_id.clone(),
             user.clone(),
             PermissionType::Read,

--- a/src/laplace_noise.rs
+++ b/src/laplace_noise.rs
@@ -61,7 +61,9 @@ impl FixedPointMath {
         let ln_val = Self::ln_1_minus_x(two_abs_u);
 
         // -b * sgn(U) * ln(...)
-        (-b * sign * ln_val) / Self::SCALE
+        // Use saturating_mul to prevent integer overflow — extremes are clamped
+        // to i128::MAX / i128::MIN so that DP noise never panics.
+        (-b).saturating_mul(sign).saturating_mul(ln_val) / Self::SCALE
     }
 }
 


### PR DESCRIPTION
## Summary

This PR resolves issues #290 and #291 assigned to @obedojukwu16-jpg.

### Issue #290: Contract Inline Tests Call Functions With Wrong Argument Counts

- Added `caller: Address` parameter to `grant_access`, `revoke_access`, and `create_access_key` in `contracts/src/access_control.rs`
- Added `caller.require_auth()` to enforce caller authentication
- Fixed a bug where `is_authorized` was checking `resource_owner.owner` instead of `caller`
- Updated `contracts/src/access_control_tests.rs` to pass the `caller` parameter and added `env.mock_all_auths()` to all tests

### Issue #291: laplace_noise Integer Overflow in Noise Calculation

- Replaced unchecked multiplication `(-b * sign * ln_val)` with safe `saturating_mul()` chain in `src/laplace_noise.rs`
- Extreme values now clamp to `i128::MAX`/`i128::MIN` instead of panicking or silently wrapping

### Files Changed
- `contracts/src/access_control.rs` — added `caller` param + `require_auth()` + fixed auth check
- `contracts/src/access_control_tests.rs` — updated tests with `caller` param + `mock_all_auths()`
- `src/laplace_noise.rs` — replaced overflow-prone multiplication with `saturating_mul()`

### Testing
- CI pipeline runs: cargo test, cargo clippy, cargo fmt --check
- Tests pass for both contracts and root workspace