### PR TITLE
fix(#290): add missing caller parameter to access_control test calls

### DIFF
--- a/contracts/src/access_control_tests.rs
+++ b/contracts/src/access_control_tests.rs
@@ -76,12 +76,12 @@ mod tests {
         client.register_resource(&resource_id, &owner, &false, &1u32, &signers);
 
         let ttl: Option<u64> = Some(86400);
-        client.grant_access(&resource_id, &user, &PermissionType::Read, &ttl);
+        client.grant_access(&owner, &resource_id, &user, &PermissionType::Read, &ttl);
 
         let has_access = client.check_access(&user, &resource_id, &PermissionType::Read);
         assert!(has_access);
 
-        client.revoke_access(&resource_id, &user);
+        client.revoke_access(&owner, &resource_id, &user);
 
         let has_access_after = client.check_access(&user, &resource_id, &PermissionType::Read);
         assert!(!has_access_after);
@@ -110,7 +110,7 @@ mod tests {
         permissions.push_back(PermissionType::Read);
 
         let ttl: Option<u64> = Some(86400);
-        let key_id = client.create_access_key(&resource_id, &holder, &permissions, &ttl);
+        let key_id = client.create_access_key(&owner, &resource_id, &holder, &permissions, &ttl);
 
         assert_ne!(key_id, BytesN::<32>::from_array(&env, &[0u8; 32]));
     }
@@ -136,7 +136,7 @@ mod tests {
 
         // Grant write permission
         let no_ttl: Option<u64> = None;
-        client.grant_access(&resource_id, &user, &PermissionType::Write, &no_ttl);
+        client.grant_access(&owner, &resource_id, &user, &PermissionType::Write, &no_ttl);
 
         // Should have read access (write includes read)
         let has_read = client.check_access(&user, &resource_id, &PermissionType::Read);
@@ -172,7 +172,7 @@ mod tests {
 
         // Grant access with 1 second TTL
         let ttl: Option<u64> = Some(1);
-        client.grant_access(&resource_id, &user, &PermissionType::Read, &ttl);
+        client.grant_access(&owner, &resource_id, &user, &PermissionType::Read, &ttl);
 
         // Should have access immediately
         let has_access = client.check_access(&user, &resource_id, &PermissionType::Read);


### PR DESCRIPTION
## Summary

Fixes #290

After auth fixes added a `caller: Address` parameter to `grant_access`, `revoke_access`, and `create_access_key`, the inline Rust tests in `contracts/src/access_control_tests.rs` were never updated to pass it. This caused `cargo test` to fail with argument count mismatches.

## Changes

Added `&owner` as the caller argument to all 5 test calls:
- `grant_access` (3 calls in `test_grant_and_revoke_access`, `test_permission_hierarchy`, `test_ttl_expiration`)
- `revoke_access` (1 call in `test_grant_and_revoke_access`)
- `create_access_key` (1 call in `test_access_key_creation`)

The tests already had `env.mock_all_auths()` in setup, satisfying the `caller.require_auth()` requirement. The `owner` variable (set to `admin.clone()`) passes the authorization check since the admin is the resource owner.

## Acceptance Criteria
- [x] All test calls include the caller parameter
- [x] `env.mock_all_auths()` present in test setup (was already present)
- [ ] `cargo test` compiles and passes (to be verified by CI)