### PR TITLE
fix(metrics): persist privacy metrics to durable store (QI-036)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ pids
 *.seed
 *.pid.lock
 
+# Gateway runtime persistence (privacy metrics store, encryption keys, etc.)
+backend/data/
+data/gateway/
+
 # Coverage directory used by tools like istanbul
 coverage/
 *.lcov

--- a/backend/src/gateway/MetricsStore.ts
+++ b/backend/src/gateway/MetricsStore.ts
@@ -1,0 +1,171 @@
+import fs from "fs";
+import path from "path";
+import { randomBytes } from "crypto";
+import { logger } from "../utils/logger";
+import { PrivacyMetric } from "./PrivacyMetrics";
+
+/**
+ * Durable, append-only persistence layer for privacy metrics.
+ *
+ * Records are written as JSON Lines (one JSON object per line) so that a flush
+ * is a cheap append rather than a full-file rewrite, and a crash mid-write only
+ * ever corrupts the trailing line — every prior record survives. On load, an
+ * unparseable trailing line is skipped instead of failing the whole recovery.
+ *
+ * Records sharing a `requestId` are de-duplicated on load with last-write-wins,
+ * so an updated metric (e.g. via recordResponse) can simply be re-appended and
+ * the latest version is what surfaces after a restart.
+ */
+export interface MetricsStoreOptions {
+  filePath?: string;
+  /** Drop persisted records older than this many milliseconds on load/compact. */
+  retentionPeriod?: number;
+}
+
+interface SerializedPrivacyMetric extends Omit<PrivacyMetric, "timestamp"> {
+  timestamp: string;
+}
+
+export class MetricsStore {
+  private readonly filePath: string;
+  private readonly retentionPeriod: number;
+
+  constructor(options: MetricsStoreOptions = {}) {
+    this.filePath =
+      options.filePath ??
+      process.env.PRIVACY_METRICS_STORE_PATH ??
+      path.join(process.cwd(), "data", "gateway", "privacy-metrics.jsonl");
+
+    this.retentionPeriod = options.retentionPeriod ?? 7 * 24 * 60 * 60 * 1000;
+  }
+
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  /**
+   * Append a batch of metrics to the durable store. Creates the parent
+   * directory on first write. A trailing newline keeps each record on its own
+   * line so a subsequent append never merges with the previous record.
+   */
+  append(metrics: PrivacyMetric[]): void {
+    if (metrics.length === 0) {
+      return;
+    }
+
+    const lines =
+      metrics
+        .map((metric) => JSON.stringify(this.serialize(metric)))
+        .join("\n") + "\n";
+
+    const directory = path.dirname(this.filePath);
+    fs.mkdirSync(directory, { recursive: true });
+
+    fs.appendFileSync(this.filePath, lines, { encoding: "utf8", mode: 0o600 });
+  }
+
+  /**
+   * Load persisted metrics, newest write winning per requestId, filtered to the
+   * retention window and (optionally) a caller-supplied time range. Returns an
+   * empty array when no store file exists yet.
+   */
+  load(timeRange?: { start: Date; end: Date }): PrivacyMetric[] {
+    if (!fs.existsSync(this.filePath)) {
+      return [];
+    }
+
+    const cutoff = new Date(Date.now() - this.retentionPeriod);
+    const byRequestId = new Map<string, PrivacyMetric>();
+
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.filePath, "utf8");
+    } catch (error) {
+      logger.error("Failed to read privacy metrics store", {
+        filePath: this.filePath,
+        error: (error as Error).message,
+      });
+      return [];
+    }
+
+    const lines = raw.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(trimmed) as SerializedPrivacyMetric;
+        const metric = this.deserialize(parsed);
+
+        if (metric.timestamp <= cutoff) {
+          continue;
+        }
+
+        // Last write wins so re-appended (updated) records supersede earlier ones.
+        byRequestId.set(metric.requestId, metric);
+      } catch {
+        // Skip a corrupt/partial line (e.g. trailing line from a crash mid-append).
+        logger.debug("Skipping unparseable privacy metrics line during load");
+      }
+    }
+
+    let records = Array.from(byRequestId.values());
+
+    if (timeRange) {
+      records = records.filter(
+        (m) => m.timestamp >= timeRange.start && m.timestamp <= timeRange.end,
+      );
+    }
+
+    return records;
+  }
+
+  /**
+   * Rewrite the store dropping records older than the retention window. Uses an
+   * atomic temp-file + rename so a crash during compaction never truncates the
+   * live store. Returns the number of records dropped.
+   */
+  compact(): number {
+    if (!fs.existsSync(this.filePath)) {
+      return 0;
+    }
+
+    const surviving = this.load();
+    const serialized =
+      surviving.length > 0
+        ? surviving
+            .map((metric) => JSON.stringify(this.serialize(metric)))
+            .join("\n") + "\n"
+        : "";
+
+    const tempPath = `${this.filePath}.${process.pid}.${randomBytes(4).toString(
+      "hex",
+    )}.tmp`;
+
+    try {
+      fs.writeFileSync(tempPath, serialized, { encoding: "utf8", mode: 0o600 });
+      fs.renameSync(tempPath, this.filePath);
+    } catch (error) {
+      if (fs.existsSync(tempPath)) {
+        fs.unlinkSync(tempPath);
+      }
+      logger.error("Failed to compact privacy metrics store", {
+        filePath: this.filePath,
+        error: (error as Error).message,
+      });
+      return 0;
+    }
+
+    return surviving.length;
+  }
+
+  private serialize(metric: PrivacyMetric): SerializedPrivacyMetric {
+    return { ...metric, timestamp: metric.timestamp.toISOString() };
+  }
+
+  private deserialize(record: SerializedPrivacyMetric): PrivacyMetric {
+    return { ...record, timestamp: new Date(record.timestamp) };
+  }
+}

--- a/backend/src/gateway/PrivacyApiGateway.ts
+++ b/backend/src/gateway/PrivacyApiGateway.ts
@@ -80,11 +80,24 @@ export interface LoadBalancingConfig {
   healthyThreshold: number;
 }
 
+export interface MetricsPersistenceConfig {
+  /** When false, metrics live only in memory (legacy behaviour). */
+  enabled: boolean;
+  /** JSONL store location. Defaults to data/gateway/privacy-metrics.jsonl. */
+  filePath?: string;
+  /** How often the in-memory buffer is flushed to disk, in ms. Default 30s. */
+  flushInterval?: number;
+  /** Hard cap on in-memory records; oldest (already-persisted) are evicted. Default 10000. */
+  maxBufferSize?: number;
+}
+
 export interface MetricsConfig {
   enabled: boolean;
   collectionInterval: number;
   retentionPeriod: number;
   exportFormat: "prometheus" | "json" | "csv";
+  /** Optional durable persistence so metrics survive a process restart. */
+  persistence?: MetricsPersistenceConfig;
 }
 
 export class PrivacyApiGateway {

--- a/backend/src/gateway/PrivacyMetrics.ts
+++ b/backend/src/gateway/PrivacyMetrics.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from "express";
 import { MetricsConfig } from "./PrivacyApiGateway";
+import { MetricsStore } from "./MetricsStore";
 import { logger } from "../utils/logger";
+
+const DEFAULT_FLUSH_INTERVAL = 30000; // 30 seconds
+const DEFAULT_MAX_BUFFER_SIZE = 10000;
 
 export interface PrivacyMetric {
   timestamp: Date;
@@ -67,17 +71,60 @@ export class PrivacyMetrics {
   private aggregationCache: Map<string, AggregatedMetrics>;
   private collectionInterval?: NodeJS.Timeout;
 
+  // Persistence: durable store + flush plumbing (no-ops when persistence is off).
+  private store?: MetricsStore;
+  private unflushed: PrivacyMetric[] = [];
+  private flushInterval?: NodeJS.Timeout;
+  private readonly flushIntervalMs: number;
+  private readonly maxBufferSize: number;
+
   constructor(config: MetricsConfig) {
     this.config = config;
     this.metrics = new Map();
     this.alerts = [];
     this.aggregationCache = new Map();
+
+    const persistence = config.persistence;
+    this.flushIntervalMs = persistence?.flushInterval ?? DEFAULT_FLUSH_INTERVAL;
+    this.maxBufferSize = persistence?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+
+    if (persistence?.enabled) {
+      this.store = new MetricsStore({
+        filePath: persistence.filePath,
+        retentionPeriod: config.retentionPeriod,
+      });
+    }
   }
 
   async start(): Promise<void> {
     if (!this.config.enabled) {
       logger.info("Privacy metrics collection disabled");
       return;
+    }
+
+    // Recover historical metrics persisted before the last shutdown/crash so
+    // getMetrics() reflects them immediately after a restart.
+    if (this.store) {
+      try {
+        const recovered = this.store.load();
+        for (const metric of recovered) {
+          this.metrics.set(metric.requestId, metric);
+        }
+        this.enforceBufferCap();
+        logger.info("Recovered persisted privacy metrics", {
+          recovered: recovered.length,
+          filePath: this.store.getFilePath(),
+        });
+      } catch (error) {
+        logger.error("Failed to recover persisted privacy metrics", {
+          error: (error as Error).message,
+        });
+      }
+
+      // Periodic flush of the in-memory buffer to the durable store.
+      this.flushInterval = setInterval(() => {
+        this.flush();
+      }, this.flushIntervalMs);
     }
 
     // Start periodic aggregation
@@ -90,6 +137,8 @@ export class PrivacyMetrics {
     logger.info("Privacy metrics collection started", {
       collectionInterval: this.config.collectionInterval,
       retentionPeriod: this.config.retentionPeriod,
+      persistence: Boolean(this.store),
+      flushInterval: this.store ? this.flushIntervalMs : undefined,
     });
   }
 
@@ -98,6 +147,14 @@ export class PrivacyMetrics {
       clearInterval(this.collectionInterval);
       this.collectionInterval = undefined;
     }
+
+    if (this.flushInterval) {
+      clearInterval(this.flushInterval);
+      this.flushInterval = undefined;
+    }
+
+    // Final flush so in-flight metrics are not lost on a graceful shutdown.
+    this.flush();
 
     logger.info("Privacy metrics collection stopped");
   }
@@ -128,6 +185,11 @@ export class PrivacyMetrics {
 
     this.metrics.set(metric.requestId, metric);
 
+    if (this.store) {
+      this.unflushed.push(metric);
+      this.enforceBufferCap();
+    }
+
     // Real-time alert checking for critical events
     if (res.statusCode === 403) {
       this.checkForImmediateAlerts(metric);
@@ -145,6 +207,12 @@ export class PrivacyMetrics {
       existingMetric.statusCode = proxyRes.statusCode;
       existingMetric.accessDecision =
         proxyRes.statusCode < 400 ? "allow" : "deny";
+
+      // Re-queue the updated record; the store de-duplicates by requestId with
+      // last-write-wins, so the persisted copy reflects the final status.
+      if (this.store) {
+        this.unflushed.push(existingMetric);
+      }
     }
   }
 
@@ -162,13 +230,7 @@ export class PrivacyMetrics {
       return cached;
     }
 
-    let filteredMetrics = Array.from(this.metrics.values());
-
-    if (timeRange) {
-      filteredMetrics = filteredMetrics.filter(
-        (m) => m.timestamp >= timeRange.start && m.timestamp <= timeRange.end,
-      );
-    }
+    const filteredMetrics = this.collectMetrics(timeRange);
 
     const aggregated = this.aggregateMetricsData(filteredMetrics);
 
@@ -182,17 +244,9 @@ export class PrivacyMetrics {
     start: Date;
     end: Date;
   }): Promise<PrivacyMetric[]> {
-    let filteredMetrics = Array.from(this.metrics.values()).filter(
+    return this.collectMetrics(timeRange).filter(
       (m) => m.accessDecision === "deny",
     );
-
-    if (timeRange) {
-      filteredMetrics = filteredMetrics.filter(
-        (m) => m.timestamp >= timeRange.start && m.timestamp <= timeRange.end,
-      );
-    }
-
-    return filteredMetrics;
   }
 
   async getAlerts(
@@ -411,6 +465,89 @@ export class PrivacyMetrics {
     });
   }
 
+  /**
+   * Build the working set for aggregation/queries. With persistence enabled the
+   * durable store is the source of truth (so trimmed-from-memory and recovered
+   * records are included), overlaid with not-yet-flushed records. Without it,
+   * the in-memory map is used as before.
+   */
+  private collectMetrics(timeRange?: {
+    start: Date;
+    end: Date;
+  }): PrivacyMetric[] {
+    if (!this.store) {
+      let arr = Array.from(this.metrics.values());
+      if (timeRange) {
+        arr = arr.filter(
+          (m) => m.timestamp >= timeRange.start && m.timestamp <= timeRange.end,
+        );
+      }
+      return arr;
+    }
+
+    const merged = new Map<string, PrivacyMetric>();
+    for (const metric of this.store.load(timeRange)) {
+      merged.set(metric.requestId, metric);
+    }
+    for (const metric of this.unflushed) {
+      if (
+        timeRange &&
+        (metric.timestamp < timeRange.start || metric.timestamp > timeRange.end)
+      ) {
+        continue;
+      }
+      merged.set(metric.requestId, metric);
+    }
+
+    return Array.from(merged.values());
+  }
+
+  /**
+   * Persist buffered metrics to the durable store. On failure the batch is
+   * re-queued so the next interval retries rather than dropping records.
+   */
+  private flush(): void {
+    if (!this.store || this.unflushed.length === 0) {
+      return;
+    }
+
+    const batch = this.unflushed;
+    this.unflushed = [];
+
+    try {
+      this.store.append(batch);
+    } catch (error) {
+      this.unflushed = batch.concat(this.unflushed);
+      logger.error("Failed to flush privacy metrics to durable store", {
+        pending: this.unflushed.length,
+        error: (error as Error).message,
+      });
+    }
+  }
+
+  /**
+   * Bound the in-memory map. Only safe with persistence on, where evicted
+   * (oldest, insertion-ordered) records remain durable in the store/flush queue.
+   */
+  private enforceBufferCap(): void {
+    if (!this.store) {
+      return;
+    }
+
+    let overflow = this.metrics.size - this.maxBufferSize;
+    if (overflow <= 0) {
+      return;
+    }
+
+    for (const id of this.metrics.keys()) {
+      if (overflow <= 0) {
+        break;
+      }
+      this.metrics.delete(id);
+      overflow--;
+    }
+  }
+
   private cleanupOldMetrics(): void {
     const cutoff = new Date(Date.now() - this.config.retentionPeriod);
     const beforeCount = this.metrics.size;
@@ -424,6 +561,12 @@ export class PrivacyMetrics {
     const removed = beforeCount - this.metrics.size;
     if (removed > 0) {
       logger.debug(`Cleaned up ${removed} old privacy metrics`);
+    }
+
+    // Drop expired records from the durable store as well.
+    if (this.store) {
+      this.flush();
+      this.store.compact();
     }
 
     // Clean up old alerts
@@ -602,6 +745,8 @@ export class PrivacyMetrics {
     activeAlerts: number;
     cacheSize: number;
     enabled: boolean;
+    persistenceEnabled: boolean;
+    pendingFlush: number;
   } {
     return {
       totalMetrics: this.metrics.size,
@@ -609,6 +754,8 @@ export class PrivacyMetrics {
       activeAlerts: this.alerts.filter((a) => !a.resolved).length,
       cacheSize: this.aggregationCache.size,
       enabled: this.config.enabled,
+      persistenceEnabled: Boolean(this.store),
+      pendingFlush: this.unflushed.length,
     };
   }
 }

--- a/backend/src/gateway/__tests__/PrivacyMetrics.test.ts
+++ b/backend/src/gateway/__tests__/PrivacyMetrics.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for PrivacyMetrics durable persistence (QI-036).
+ *
+ * Verifies that:
+ *  1. Recorded metrics are flushed to a durable JSONL store.
+ *  2. After a simulated process restart (new instance, same store file),
+ *     historical metrics are recovered and queryable via getMetrics().
+ *  3. The in-memory buffer is bounded by maxBufferSize while persisted data
+ *     remains intact.
+ *  4. recordResponse updates are persisted with last-write-wins semantics.
+ *  5. With persistence disabled the legacy in-memory-only behaviour is kept.
+ */
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { PrivacyMetrics } from "../PrivacyMetrics";
+import { MetricsStore } from "../MetricsStore";
+import { MetricsConfig } from "../PrivacyApiGateway";
+
+jest.mock("../../utils/logger", () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const RETENTION = 7 * 24 * 60 * 60 * 1000;
+
+function makeConfig(overrides: Partial<MetricsConfig> = {}): MetricsConfig {
+  return {
+    enabled: true,
+    collectionInterval: 60000,
+    retentionPeriod: RETENTION,
+    exportFormat: "json",
+    ...overrides,
+  };
+}
+
+function makeReqRes(
+  requestId: string,
+  statusCode: number,
+  overrides: Record<string, any> = {},
+) {
+  const req: any = {
+    requestId,
+    path: "/api/data",
+    method: "GET",
+    ip: "10.0.0.1",
+    headers: { "user-agent": "jest" },
+    privacyLevel: "high",
+    appliedPolicies: [],
+    appliedTransformations: [],
+    ...overrides,
+  };
+  const res: any = { statusCode };
+  return { req, res };
+}
+
+describe("PrivacyMetrics persistence (QI-036)", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "privacy-metrics-"));
+    storePath = path.join(tmpDir, "metrics.jsonl");
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function persistentConfig(overrides: Record<string, any> = {}): MetricsConfig {
+    return makeConfig({
+      persistence: {
+        enabled: true,
+        filePath: storePath,
+        flushInterval: 1000,
+        maxBufferSize: 5,
+        ...overrides,
+      },
+    });
+  }
+
+  it("flushes recorded metrics to the durable store", async () => {
+    const metrics = new PrivacyMetrics(persistentConfig());
+    await metrics.start();
+
+    for (let i = 0; i < 3; i++) {
+      const { req, res } = makeReqRes(`req-${i}`, 200);
+      metrics.recordRequest(req, res, 10);
+    }
+
+    // Trigger the flush interval.
+    jest.advanceTimersByTime(1000);
+
+    expect(fs.existsSync(storePath)).toBe(true);
+    const persisted = new MetricsStore({
+      filePath: storePath,
+      retentionPeriod: RETENTION,
+    }).load();
+    expect(persisted).toHaveLength(3);
+
+    await metrics.stop();
+  });
+
+  it("recovers historical metrics after a restart", async () => {
+    // First "process" records metrics and shuts down.
+    const first = new PrivacyMetrics(persistentConfig());
+    await first.start();
+    for (let i = 0; i < 4; i++) {
+      const { req, res } = makeReqRes(`req-${i}`, i === 0 ? 403 : 200);
+      first.recordRequest(req, res, 5);
+    }
+    await first.stop(); // final flush
+
+    // Second "process" starts fresh against the same store file.
+    const second = new PrivacyMetrics(persistentConfig());
+    await second.start();
+
+    const aggregated = await second.getMetrics();
+    expect(aggregated.totalRequests).toBe(4);
+    expect(aggregated.blockedRequests).toBe(1);
+    expect(aggregated.successfulRequests).toBe(3);
+
+    const violations = await second.getPrivacyViolations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0].requestId).toBe("req-0");
+
+    await second.stop();
+  });
+
+  it("bounds the in-memory buffer while keeping persisted data intact", async () => {
+    const metrics = new PrivacyMetrics(persistentConfig({ maxBufferSize: 5 }));
+    await metrics.start();
+
+    for (let i = 0; i < 20; i++) {
+      const { req, res } = makeReqRes(`req-${i}`, 200);
+      metrics.recordRequest(req, res, 1);
+    }
+
+    // In-memory map is capped...
+    expect(metrics.getStats().totalMetrics).toBeLessThanOrEqual(5);
+
+    // ...but every record is still queryable (from the store + flush buffer).
+    jest.advanceTimersByTime(1000);
+    const aggregated = await metrics.getMetrics();
+    expect(aggregated.totalRequests).toBe(20);
+
+    await metrics.stop();
+  });
+
+  it("persists recordResponse updates with last-write-wins", async () => {
+    const metrics = new PrivacyMetrics(persistentConfig());
+    await metrics.start();
+
+    const { req, res } = makeReqRes("req-update", 200);
+    metrics.recordRequest(req, res, 8);
+    // Proxy response later flips the decision to denied.
+    metrics.recordResponse(req, { statusCode: 403 });
+
+    await metrics.stop();
+
+    const restarted = new PrivacyMetrics(persistentConfig());
+    await restarted.start();
+    const aggregated = await restarted.getMetrics();
+    expect(aggregated.totalRequests).toBe(1);
+    expect(aggregated.blockedRequests).toBe(1);
+    await restarted.stop();
+  });
+
+  it("keeps legacy in-memory behaviour when persistence is disabled", async () => {
+    const metrics = new PrivacyMetrics(makeConfig());
+    await metrics.start();
+
+    const { req, res } = makeReqRes("req-mem", 200);
+    metrics.recordRequest(req, res, 3);
+
+    expect(metrics.getStats().persistenceEnabled).toBe(false);
+    expect(fs.existsSync(storePath)).toBe(false);
+
+    const aggregated = await metrics.getMetrics();
+    expect(aggregated.totalRequests).toBe(1);
+
+    await metrics.stop();
+  });
+});
+
+describe("MetricsStore", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "metrics-store-"));
+    storePath = path.join(tmpDir, "store.jsonl");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function record(requestId: string, timestamp: Date): any {
+    return {
+      timestamp,
+      requestId,
+      endpoint: "/x",
+      method: "GET",
+      statusCode: 200,
+      responseTime: 1,
+      privacyLevel: "high",
+      policiesApplied: [],
+      transformationsApplied: [],
+      accessDecision: "allow",
+      dataClassification: "unknown",
+      jurisdiction: "unknown",
+      ipAddress: "1.1.1.1",
+      userAgent: "test",
+    };
+  }
+
+  it("appends and reloads records, reviving Date timestamps", () => {
+    const store = new MetricsStore({ filePath: storePath });
+    const now = new Date();
+    store.append([record("a", now), record("b", now)]);
+
+    const loaded = store.load();
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it("de-duplicates by requestId with last-write-wins", () => {
+    const store = new MetricsStore({ filePath: storePath });
+    const now = new Date();
+    const first = record("dup", now);
+    const second = { ...record("dup", now), accessDecision: "deny" };
+    store.append([first]);
+    store.append([second]);
+
+    const loaded = store.load();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].accessDecision).toBe("deny");
+  });
+
+  it("drops records older than the retention window on load", () => {
+    const store = new MetricsStore({
+      filePath: storePath,
+      retentionPeriod: 1000,
+    });
+    const old = new Date(Date.now() - 5000);
+    const fresh = new Date();
+    store.append([record("old", old), record("fresh", fresh)]);
+
+    const loaded = store.load();
+    expect(loaded.map((m) => m.requestId)).toEqual(["fresh"]);
+  });
+
+  it("skips a corrupt trailing line instead of failing recovery", () => {
+    const store = new MetricsStore({ filePath: storePath });
+    store.append([record("ok", new Date())]);
+    // Simulate a partial write from a crash.
+    fs.appendFileSync(storePath, '{"requestId":"broken","timestamp":');
+
+    const loaded = store.load();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].requestId).toBe("ok");
+  });
+
+  it("compacts away expired records using an atomic rewrite", () => {
+    const store = new MetricsStore({
+      filePath: storePath,
+      retentionPeriod: 1000,
+    });
+    store.append([
+      record("old", new Date(Date.now() - 5000)),
+      record("fresh", new Date()),
+    ]);
+
+    const survivors = store.compact();
+    expect(survivors).toBe(1);
+
+    const raw = fs.readFileSync(storePath, "utf8").trim().split("\n");
+    expect(raw).toHaveLength(1);
+    expect(raw[0]).toContain("fresh");
+  });
+});

--- a/backend/src/gateway/index.ts
+++ b/backend/src/gateway/index.ts
@@ -225,6 +225,11 @@ export const defaultGatewayConfig: GatewayConfig = {
     collectionInterval: 60000, // 1 minute
     retentionPeriod: 7 * 24 * 60 * 60 * 1000, // 7 days
     exportFormat: "prometheus",
+    persistence: {
+      enabled: true,
+      flushInterval: 30000, // 30 seconds
+      maxBufferSize: 10000,
+    },
   },
 };
 


### PR DESCRIPTION
# QI-036: Persist Privacy Metrics to a Durable Store

Closes #254

## Files Changed
| File | Change |
|---|---|
| `backend/src/gateway/MetricsStore.ts` | **New** — durable JSONL store (append, load, compact) |
| `backend/src/gateway/PrivacyMetrics.ts` | Flush plumbing, recovery, bounded buffer, store-backed queries |
| `backend/src/gateway/PrivacyApiGateway.ts` | New `MetricsPersistenceConfig` + `persistence` field on `MetricsConfig` |
| `backend/src/gateway/index.ts` | Enable persistence in default gateway config |
| `backend/src/gateway/__tests__/PrivacyMetrics.test.ts` | **New** — 10 tests |
| `.gitignore` | Ignore gateway runtime data dirs |
