### PR TITLE
feat(validation): export inferred TypeScript types for Zod schemas 

### DIFF
--- a/shared/src/validation/__tests__/inferredTypes.test.ts
+++ b/shared/src/validation/__tests__/inferredTypes.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for the inferred validation types exported from the schemas (QI-039).
+ *
+ * Because the suite runs under ts-jest, the type-level assertions below are
+ * checked at compile time: if a schema-inferred type stops lining up with its
+ * canonical domain interface, this file fails to compile. The runtime cases
+ * additionally confirm that `ValidationService` returns data shaped like the
+ * exported inferred types.
+ */
+
+import {
+  ValidationService,
+  PrivacySettingsSchema,
+  DataSchemaSchema,
+  AnalysisParametersSchema,
+  XRayAnalysisSchema,
+  VisualizationConfigSchema,
+  ValidatedPrivacySettings,
+  ValidatedDataField,
+  ValidatedDataSchema,
+  ValidatedAnalysisParameters,
+  ValidatedXRayAnalysis,
+  ValidatedVisualizationConfig,
+} from "../index";
+import {
+  PrivacyLevel,
+  AnonymizationTechnique,
+  DataType,
+  PrivacySettings,
+  DataField,
+  DataSchema,
+} from "../../types/privacy";
+import {
+  AnalysisType,
+  AggregationType,
+  NoiseMechanism,
+  AnonymizationLevel,
+  AnalysisStatus,
+  VisualizationType,
+  AnalysisParameters,
+  XRayAnalysis,
+  VisualizationConfig,
+} from "../../types/analytics";
+
+// ---------------------------------------------------------------------------
+// Compile-time: a canonical domain object is assignable to the inferred type,
+// and the inferred type is exported and usable as an annotation. (The issue's
+// reproduction: annotate a value with the schema's type without re-declaring.)
+// ---------------------------------------------------------------------------
+describe("exported inferred validation types (compile-time)", () => {
+  it("accepts canonical domain objects as inferred types", () => {
+    const privacy: PrivacySettings = {
+      level: PrivacyLevel.HIGH,
+      dataRetentionDays: 30,
+      allowDataExport: false,
+      allowSharing: false,
+      differentialPrivacyEpsilon: 1,
+      minimumParticipants: 5,
+      anonymizationTechnique: AnonymizationTechnique.K_ANONYMITY,
+    };
+    const validatedPrivacy: ValidatedPrivacySettings = privacy;
+    expect(validatedPrivacy.level).toBe(PrivacyLevel.HIGH);
+
+    const field: DataField = {
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "age",
+      type: DataType.NUMERICAL,
+      required: true,
+      sensitive: false,
+      encryptionRequired: false,
+    };
+    const validatedField: ValidatedDataField = field;
+    expect(validatedField.name).toBe("age");
+
+    const schema: DataSchema = {
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "dataset",
+      fields: [field],
+      privacySettings: privacy,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const validatedSchema: ValidatedDataSchema = schema;
+    expect(validatedSchema.fields).toHaveLength(1);
+
+    const params: AnalysisParameters = {
+      fields: ["age"],
+      aggregations: [AggregationType.COUNT, AggregationType.AVERAGE],
+      privacyBudget: 1,
+    };
+    const validatedParams: ValidatedAnalysisParameters = params;
+    expect(validatedParams.fields).toEqual(["age"]);
+
+    const viz: VisualizationConfig = {
+      type: VisualizationType.BAR_CHART,
+      title: "chart",
+      dataSource: "ds",
+      config: {},
+    };
+    const validatedViz: ValidatedVisualizationConfig = viz;
+    expect(validatedViz.type).toBe(VisualizationType.BAR_CHART);
+
+    const xray: XRayAnalysis = {
+      id: "33333333-3333-4333-8333-333333333333",
+      name: "analysis",
+      description: "desc",
+      type: AnalysisType.DESCRIPTIVE,
+      parameters: params,
+      privacySettings: {
+        differentialPrivacyEpsilon: 1,
+        minimumSampleSize: 5,
+        noiseMechanism: NoiseMechanism.LAPLACE,
+        anonymizationLevel: AnonymizationLevel.MEDIUM,
+      },
+      status: AnalysisStatus.PENDING,
+      createdAt: new Date(),
+    };
+    const validatedXray: ValidatedXRayAnalysis = xray;
+    expect(validatedXray.status).toBe(AnalysisStatus.PENDING);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime: schemas accept the same enum string values they did before the
+// nativeEnum refactor, and ValidationService returns the inferred shapes.
+// ---------------------------------------------------------------------------
+describe("schema validation runtime behaviour", () => {
+  it("parses a valid PrivacySettings into the inferred type", () => {
+    const result = ValidationService.validatePrivacySettings({
+      level: PrivacyLevel.STANDARD,
+      dataRetentionDays: 90,
+      allowDataExport: true,
+      allowSharing: false,
+      differentialPrivacyEpsilon: 0.5,
+      minimumParticipants: 3,
+      anonymizationTechnique: AnonymizationTechnique.DIFFERENTIAL_PRIVACY,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data: ValidatedPrivacySettings = result.data;
+      expect(data.dataRetentionDays).toBe(90);
+    }
+  });
+
+  it("accepts enum string values for analysis aggregations", () => {
+    const result = AnalysisParametersSchema.safeParse({
+      fields: ["a"],
+      aggregations: ["count", "sum"], // raw enum string values
+      privacyBudget: 1,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.aggregations).toEqual([
+        AggregationType.COUNT,
+        AggregationType.SUM,
+      ]);
+    }
+  });
+
+  it("accepts enum string values for X-Ray privacy settings and status", () => {
+    const result = XRayAnalysisSchema.safeParse({
+      id: "44444444-4444-4444-8444-444444444444",
+      name: "a",
+      description: "d",
+      type: "descriptive",
+      parameters: { fields: ["a"], privacyBudget: 1 },
+      privacySettings: {
+        differentialPrivacyEpsilon: 1,
+        minimumSampleSize: 5,
+        noiseMechanism: "gaussian",
+        anonymizationLevel: "high",
+      },
+      status: "running",
+      createdAt: new Date(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid enum values", () => {
+    const result = AnalysisParametersSchema.safeParse({
+      fields: ["a"],
+      aggregations: ["not_a_real_aggregation"],
+      privacyBudget: 1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates a DataSchema and VisualizationConfig end to end", () => {
+    const schemaResult = ValidationService.validateDataSchema({
+      id: "55555555-5555-4555-8555-555555555555",
+      name: "dataset",
+      fields: [
+        {
+          id: "66666666-6666-4666-8666-666666666666",
+          name: "age",
+          type: DataType.NUMERICAL,
+          required: true,
+          sensitive: false,
+          encryptionRequired: false,
+        },
+      ],
+      privacySettings: {
+        level: PrivacyLevel.HIGH,
+        dataRetentionDays: 30,
+        allowDataExport: false,
+        allowSharing: false,
+        differentialPrivacyEpsilon: 1,
+        minimumParticipants: 2,
+        anonymizationTechnique: AnonymizationTechnique.K_ANONYMITY,
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    expect(schemaResult.success).toBe(true);
+
+    const vizResult = ValidationService.validateVisualizationConfig({
+      type: VisualizationType.LINE_CHART,
+      title: "trend",
+      dataSource: "ds",
+      config: { x: "time" },
+    });
+    expect(vizResult.success).toBe(true);
+  });
+
+  // Reference the remaining schema imports so the type-only intent is explicit.
+  it("exposes the schemas used by consumers", () => {
+    expect(PrivacySettingsSchema).toBeDefined();
+    expect(DataSchemaSchema).toBeDefined();
+    expect(VisualizationConfigSchema).toBeDefined();
+  });
+});

--- a/shared/src/validation/index.ts
+++ b/shared/src/validation/index.ts
@@ -3,8 +3,21 @@ import {
   PrivacyLevel,
   DataType,
   AnonymizationTechnique,
+  PrivacySettings,
+  DataField,
+  DataSchema,
 } from "../types/privacy";
-import { AnalysisType, VisualizationType } from "../types/analytics";
+import {
+  AnalysisType,
+  VisualizationType,
+  AggregationType,
+  NoiseMechanism,
+  AnonymizationLevel,
+  AnalysisStatus,
+  AnalysisParameters,
+  XRayAnalysis,
+  VisualizationConfig,
+} from "../types/analytics";
 
 // Privacy Settings Validation
 export const PrivacySettingsSchema = z.object({
@@ -68,11 +81,7 @@ export const AnalysisParametersSchema = z.object({
     )
     .optional(),
   groupBy: z.array(z.string()).optional(),
-  aggregations: z
-    .array(
-      z.enum(["count", "sum", "average", "median", "min", "max", "std_dev"]),
-    )
-    .optional(),
+  aggregations: z.array(z.nativeEnum(AggregationType)).optional(),
   timeRange: z
     .object({
       start: z.date(),
@@ -92,10 +101,10 @@ export const XRayAnalysisSchema = z.object({
   privacySettings: z.object({
     differentialPrivacyEpsilon: z.number().min(0.01).max(10),
     minimumSampleSize: z.number().min(2),
-    noiseMechanism: z.enum(["laplace", "gaussian", "exponential"]),
-    anonymizationLevel: z.enum(["none", "low", "medium", "high"]),
+    noiseMechanism: z.nativeEnum(NoiseMechanism),
+    anonymizationLevel: z.nativeEnum(AnonymizationLevel),
   }),
-  status: z.enum(["pending", "running", "completed", "failed", "cancelled"]),
+  status: z.nativeEnum(AnalysisStatus),
   results: z.any().optional(),
   createdAt: z.date(),
   completedAt: z.date().optional(),
@@ -117,6 +126,66 @@ export const VisualizationConfigSchema = z.object({
     )
     .optional(),
 });
+
+// ---------------------------------------------------------------------------
+// Inferred TypeScript types (QI-039)
+//
+// Canonical, schema-derived types so consumers never re-declare a shape by
+// hand. None of the schemas above use transforms/coercion, so the inferred
+// output type (`z.infer`) is identical to the input type.
+//
+// The plain domain names (`PrivacySettings`, `DataSchema`, ...) are already
+// exported as hand-written interfaces from `../types/*` and re-exported through
+// the package barrel, so these inferred aliases use a `Validated` prefix to
+// stay collision-free while remaining unambiguously the schema's source of
+// truth. The drift guards below fail `tsc --noEmit` if a schema and its
+// canonical interface ever diverge.
+// ---------------------------------------------------------------------------
+export type ValidatedPrivacySettings = z.infer<typeof PrivacySettingsSchema>;
+export type ValidatedDataField = z.infer<typeof DataFieldSchema>;
+export type ValidatedDataSchema = z.infer<typeof DataSchemaSchema>;
+export type ValidatedAnalysisParameters = z.infer<
+  typeof AnalysisParametersSchema
+>;
+export type ValidatedXRayAnalysis = z.infer<typeof XRayAnalysisSchema>;
+export type ValidatedVisualizationConfig = z.infer<
+  typeof VisualizationConfigSchema
+>;
+
+// --- Compile-time drift guards --------------------------------------------
+// `Expect<...>` only accepts `true`, so a divergence collapses the argument to
+// `false` and raises a type error under `tsc --noEmit`, keeping each schema in
+// step with its canonical domain interface.
+//
+// The invariant asserted is: every canonical domain object is a valid instance
+// of the schema-inferred type. (Exact bidirectional equality is intentionally
+// not used: `z.any()` fields such as `validationRules[].value` are inferred as
+// optional, which never exactly equals a required interface field even though
+// the shapes are compatible.) This catches the realistic drifts — a schema
+// adding/renaming a required field, or changing a field's/enum's type.
+type Expect<T extends true> = T;
+type CanonicalIsValid<Canonical, Validated> = [Canonical] extends [Validated]
+  ? true
+  : false;
+
+/* eslint-disable @typescript-eslint/no-unused-vars -- guards exist only for their compile-time check */
+type _GuardPrivacySettings = Expect<
+  CanonicalIsValid<PrivacySettings, ValidatedPrivacySettings>
+>;
+type _GuardDataField = Expect<CanonicalIsValid<DataField, ValidatedDataField>>;
+type _GuardDataSchema = Expect<
+  CanonicalIsValid<DataSchema, ValidatedDataSchema>
+>;
+type _GuardVisualizationConfig = Expect<
+  CanonicalIsValid<VisualizationConfig, ValidatedVisualizationConfig>
+>;
+type _GuardAnalysisParameters = Expect<
+  CanonicalIsValid<AnalysisParameters, ValidatedAnalysisParameters>
+>;
+type _GuardXRayAnalysis = Expect<
+  CanonicalIsValid<XRayAnalysis, ValidatedXRayAnalysis>
+>;
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
 // Validation Utilities
 export class ValidationService {


### PR DESCRIPTION
Closes #257

## Solution
All changes are contained to `shared/src/validation/index.ts` (plus a new test).

### 1. Export inferred types for every schema
```ts
export type ValidatedPrivacySettings     = z.infer<typeof PrivacySettingsSchema>;
export type ValidatedDataField           = z.infer<typeof DataFieldSchema>;
export type ValidatedDataSchema          = z.infer<typeof DataSchemaSchema>;
export type ValidatedAnalysisParameters  = z.infer<typeof AnalysisParametersSchema>;
export type ValidatedXRayAnalysis        = z.infer<typeof XRayAnalysisSchema>;
export type ValidatedVisualizationConfig = z.infer<typeof VisualizationConfigSchema>;
```
The `Validated` prefix is deliberate: the plain domain names (`PrivacySettings`, `DataSchema`, …) are already exported as hand-written interfaces from `../types/*` and re-exported through the package barrel (`shared/src/index.ts`). Exporting the inferred types under the same names would make every one of those names **ambiguous** through the barrel and break existing consumers. The prefix keeps them collision-free while remaining unambiguously the schema-derived types.

### 2. Align enum fields with the canonical domain enums
Several schema fields encoded enums as raw string-literal unions, so their inferred types didn't match the canonical enum-based interfaces. Refactored to `z.nativeEnum(...)`:
- `AnalysisParametersSchema.aggregations` → `z.nativeEnum(AggregationType)`
- `XRayAnalysisSchema.privacySettings.noiseMechanism` → `z.nativeEnum(NoiseMechanism)`
- `XRayAnalysisSchema.privacySettings.anonymizationLevel` → `z.nativeEnum(AnonymizationLevel)`
- `XRayAnalysisSchema.status` → `z.nativeEnum(AnalysisStatus)`

## Files Changed
| File | Change |
|---|---|
| `shared/src/validation/index.ts` | Export inferred types, `z.nativeEnum` refactor, drift guards |
| `shared/src/validation/__tests__/inferredTypes.test.ts` | **New** — type-level + runtime tests |
