### PR TITLE
fix(privacy_oracle): decrement total_fees_collected on cancel (#280)

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -13,6 +13,8 @@ mod access_control_tests;
 #[cfg(test)]
 mod invariant_testing_tests;
 #[cfg(test)]
+mod privacy_oracle_tests;
+#[cfg(test)]
 mod upgradeable_proxy_tests;
 
 pub use access_control::DataSovereigntyAccessControl;

--- a/contracts/src/privacy_oracle.rs
+++ b/contracts/src/privacy_oracle.rs
@@ -372,6 +372,22 @@ impl PrivacyOracle {
         let current_deposit = Self::get_user_deposit(env.clone(), cancel_requester.clone());
         Self::set_user_deposit(env.clone(), cancel_requester, current_deposit + refund);
 
+        // The full fee was added to total_fees_collected at request time, but
+        // only the non-refunded portion (fee - refund) is actually retained.
+        // Decrement by the refunded amount so the global counter reflects the
+        // net fee collected instead of diverging with every cancellation.
+        if refund > 0 {
+            let total_fees_collected: i128 = env
+                .storage()
+                .instance()
+                .get(&Symbol::new(&env, "total_fees_collected"))
+                .unwrap_or(0);
+            env.storage().instance().set(
+                &Symbol::new(&env, "total_fees_collected"),
+                &(total_fees_collected - refund),
+            );
+        }
+
         // Remove from pending requests
         Self::remove_from_pending(env.clone(), request_id.clone());
 

--- a/contracts/src/privacy_oracle_tests.rs
+++ b/contracts/src/privacy_oracle_tests.rs
@@ -1,0 +1,117 @@
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{Address, BytesN, Env, String, Vec};
+
+    use crate::privacy_oracle::{PrivacyOracle, PrivacyOracleClient};
+
+    // "market_data" fee configured in PrivacyOracle::initialize (0.05 XLM).
+    const MARKET_DATA_FEE: i128 = 50_000_000;
+
+    struct Harness<'a> {
+        env: Env,
+        client: PrivacyOracleClient<'a>,
+        // The contract's own address doubles as admin/requester/oracle because
+        // every entrypoint derives the caller from env.current_contract_address().
+        actor: Address,
+    }
+
+    fn setup(env: &Env) -> Harness<'_> {
+        env.mock_all_auths();
+        let contract_id = env.register(PrivacyOracle, ());
+        let client = PrivacyOracleClient::new(env, &contract_id);
+        let actor: Address = env.as_contract(&contract_id, || env.current_contract_address());
+        client.initialize(&actor);
+        Harness {
+            env: env.clone(),
+            client,
+            actor,
+        }
+    }
+
+    // `seed` distinguishes the data_hash so otherwise-identical requests hash to
+    // distinct request IDs (the ID also folds in ledger time/sequence, which do
+    // not advance between calls in a single test).
+    fn request_market_data(h: &Harness, seed: u8) -> BytesN<32> {
+        let data_source = String::from_str(&h.env, "market_data");
+        let data_hash = BytesN::<32>::from_array(&h.env, &[seed; 32]);
+        h.client.request_data(&data_source, &data_hash, &2u32)
+    }
+
+    /// Acceptance: create request -> cancel -> total_fees_collected reflects the
+    /// net fee actually retained (fee - 50% refund).
+    #[test]
+    fn test_cancel_request_decrements_total_fees_to_net_fee() {
+        let env = Env::default();
+        let h = setup(&env);
+
+        h.client.add_deposit(&MARKET_DATA_FEE);
+        let request_id = request_market_data(&h, 1);
+
+        // Full fee booked on request.
+        let (_requests, fees_after_request, _nodes) = h.client.get_stats();
+        assert_eq!(fees_after_request, MARKET_DATA_FEE);
+
+        h.client.cancel_request(&request_id);
+
+        // 50% refunded, so the counter must reflect the net fee (fee - refund).
+        let refund = MARKET_DATA_FEE / 2;
+        let net_fee = MARKET_DATA_FEE - refund;
+        let (_r, fees_after_cancel, _n) = h.client.get_stats();
+        assert_eq!(fees_after_cancel, net_fee);
+        assert_eq!(fees_after_cancel, 25_000_000);
+    }
+
+    /// Acceptance: create request -> fulfill -> total_fees_collected reflects the
+    /// full fee (fulfilment retains the entire fee, no refund).
+    #[test]
+    fn test_fulfill_request_keeps_full_fee() {
+        let env = Env::default();
+        let h = setup(&env);
+
+        // Register the actor as an active oracle so fulfilment is authorized.
+        h.client
+            .add_oracle_node(&h.actor, &String::from_str(&env, "http://oracle.local"));
+
+        h.client.add_deposit(&MARKET_DATA_FEE);
+        let request_id = request_market_data(&h, 1);
+
+        let result_hash = BytesN::<32>::from_array(&env, &[2u8; 32]);
+        let privacy_proofs: Vec<BytesN<32>> = Vec::new(&env);
+        h.client
+            .fulfill_request(&request_id, &result_hash, &privacy_proofs, &95u32);
+
+        let (_r, fees_after_fulfill, _n) = h.client.get_stats();
+        assert_eq!(fees_after_fulfill, MARKET_DATA_FEE);
+    }
+
+    /// The counter must track net fees consistently across interleaved
+    /// fulfil/cancel operations rather than drifting upward per cancellation.
+    #[test]
+    fn test_total_fees_collected_tracks_net_across_multiple_requests() {
+        let env = Env::default();
+        let h = setup(&env);
+
+        h.client
+            .add_oracle_node(&h.actor, &String::from_str(&env, "http://oracle.local"));
+        h.client.add_deposit(&(MARKET_DATA_FEE * 3));
+
+        // Request #1 -> fulfilled (retains full fee).
+        let req1 = request_market_data(&h, 1);
+        let result_hash = BytesN::<32>::from_array(&env, &[2u8; 32]);
+        let proofs: Vec<BytesN<32>> = Vec::new(&env);
+        h.client
+            .fulfill_request(&req1, &result_hash, &proofs, &90u32);
+
+        // Request #2 and #3 -> cancelled (retains 50% each).
+        let req2 = request_market_data(&h, 2);
+        let req3 = request_market_data(&h, 3);
+        h.client.cancel_request(&req2);
+        h.client.cancel_request(&req3);
+
+        // Net = full fee + 2 * (fee - refund).
+        let refund = MARKET_DATA_FEE / 2;
+        let expected = MARKET_DATA_FEE + 2 * (MARKET_DATA_FEE - refund);
+        let (_r, total_fees, _n) = h.client.get_stats();
+        assert_eq!(total_fees, expected);
+    }
+}


### PR DESCRIPTION
# [HIGH] Fix: `cancel_request` now decrements `total_fees_collected`

Fixes #280

## Problem
In `contracts/src/privacy_oracle.rs`, `request_data` adds the **full fee** to the global `total_fees_collected` counter. When a request is cancelled, `cancel_request` refunds **50%** of the fee to the user's deposit but **never decremented the counter**. The result: `total_fees_collected` permanently overstated revenue and diverged further with every cancellation.

| Step | Fee flow | Counter (before fix) | Counter (after fix) |
|---|---|---|---|
| `request_data` | +50,000,000 booked | 50,000,000 | 50,000,000 |
| `cancel_request` | 25,000,000 refunded | **50,000,000** ❌ | **25,000,000** ✅ |

## Fix
Decrement `total_fees_collected` by the refunded amount during cancellation, so the counter reflects the **net fee retained** (`fee - refund`):

```rust
// The full fee was added to total_fees_collected at request time, but
// only the non-refunded portion (fee - refund) is actually retained.
// Decrement by the refunded amount so the global counter reflects the
// net fee collected instead of diverging with every cancellation.
if refund > 0 {
    let total_fees_collected: i128 = env.storage().instance()
        .get(&Symbol::new(&env, "total_fees_collected")).unwrap_or(0);
    env.storage().instance().set(
        &Symbol::new(&env, "total_fees_collected"),
        &(total_fees_collected - refund),
    );
}
```

After cancellation the counter holds `fee - refund` (the net fee). Fulfilment is unaffected and continues to retain the full fee.

## Tests
New `contracts/src/privacy_oracle_tests.rs` (registered in `lib.rs`):

| Test | Covers |
|---|---|
| `test_cancel_request_decrements_total_fees_to_net_fee` | **Acceptance**: create → cancel → counter == net fee (`fee - refund` = 25,000,000) |
| `test_fulfill_request_keeps_full_fee` | **Acceptance**: create → fulfil → counter == full fee (50,000,000) |
| `test_total_fees_collected_tracks_net_across_multiple_requests` | Counter stays correct across interleaved fulfil/cancel cycles (doesn't drift upward) |

```
running 3 tests
test ...test_cancel_request_decrements_total_fees_to_net_fee ... ok
test ...test_fulfill_request_keeps_full_fee ... ok
test ...test_total_fees_collected_tracks_net_across_multiple_requests ... ok
test result: ok. 3 passed; 0 failed
```

## Files Changed
| File | Change |
|---|---|
| `contracts/src/privacy_oracle.rs` | Decrement `total_fees_collected` by the refund in `cancel_request` |
| `contracts/src/privacy_oracle_tests.rs` | **New** — 3 tests |
| `contracts/src/lib.rs` | Register the test module |


