### PR TITLE
fix(schema_enforcer): populate validation_logs index (#281)

### DIFF
--- a/contracts/src/schema_enforcer.rs
+++ b/contracts/src/schema_enforcer.rs
@@ -290,6 +290,18 @@ impl SchemaEnforcer {
         // Store validation log
         env.storage().persistent().set(&log_id, &validation_log);
 
+        // Append the log id to the validation_logs index that get_validation_log
+        // scans. Without this the index stays empty and every audit lookup
+        // returns None, silently losing the validation trail.
+        let logs_key = Symbol::new(&env, "validation_logs");
+        let mut validation_logs: Vec<BytesN<32>> = env
+            .storage()
+            .persistent()
+            .get(&logs_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        validation_logs.push_back(log_id.clone());
+        env.storage().persistent().set(&logs_key, &validation_logs);
+
         // If validation failed, create rejection event
         if !validation_log.validation_result {
             let rejection_id = Self::generate_rejection_id(&env, &payload.payload_id);
@@ -526,5 +538,100 @@ impl SchemaEnforcer {
             | SchemaFieldType::EncryptedFloat => !_encrypted_data.is_empty(),
             _ => false, // Non-encrypted types shouldn't be in encrypted fields
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    /// Register a schema with no fields/metadata so any payload validates
+    /// cleanly, keeping these tests focused on the validation-log index.
+    fn create_empty_schema(
+        env: &Env,
+        client: &SchemaEnforcerClient,
+        org_id: &Address,
+    ) -> BytesN<32> {
+        let fields: Vec<SchemaField> = Vec::new(env);
+        let required_metadata: Vec<String> = Vec::new(env);
+        client.create_schema(
+            org_id,
+            &String::from_str(env, "schema"),
+            &String::from_str(env, "v1"),
+            &fields,
+            &required_metadata,
+        )
+    }
+
+    fn payload_for(env: &Env, schema_id: &BytesN<32>, seed: u8) -> EncryptedPayload {
+        EncryptedPayload {
+            payload_id: BytesN::<32>::from_array(env, &[seed; 32]),
+            schema_id: schema_id.clone(),
+            provider_id: Address::generate(env),
+            data_hash: BytesN::<32>::from_array(env, &[seed.wrapping_add(1); 32]),
+            encrypted_fields: Map::new(env),
+            metadata: Map::new(env),
+            timestamp: 0,
+        }
+    }
+
+    /// Acceptance: validate a payload, then retrieve its log successfully.
+    #[test]
+    fn test_validation_log_is_indexed_and_retrievable() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SchemaEnforcer, ());
+        let client = SchemaEnforcerClient::new(&env, &contract_id);
+
+        let org_id = Address::generate(&env);
+        let schema_id = create_empty_schema(&env, &client, &org_id);
+
+        let payload = payload_for(&env, &schema_id, 7);
+        let log_id = client.validate_payload(&payload);
+
+        let log = client.get_validation_log(&payload.payload_id);
+        assert!(
+            log.is_some(),
+            "validation log should be retrievable after validate_payload"
+        );
+        let log = log.unwrap();
+        assert_eq!(log.log_id, log_id);
+        assert_eq!(log.payload_id, payload.payload_id);
+        assert!(log.validation_result);
+    }
+
+    /// Multiple validated payloads must each be independently retrievable,
+    /// proving the index accumulates entries rather than overwriting.
+    #[test]
+    fn test_multiple_validation_logs_are_each_retrievable() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SchemaEnforcer, ());
+        let client = SchemaEnforcerClient::new(&env, &contract_id);
+
+        let org_id = Address::generate(&env);
+        let schema_id = create_empty_schema(&env, &client, &org_id);
+
+        let payload_a = payload_for(&env, &schema_id, 10);
+        let payload_b = payload_for(&env, &schema_id, 20);
+        client.validate_payload(&payload_a);
+        client.validate_payload(&payload_b);
+
+        let log_a = client.get_validation_log(&payload_a.payload_id);
+        let log_b = client.get_validation_log(&payload_b.payload_id);
+        assert_eq!(log_a.unwrap().payload_id, payload_a.payload_id);
+        assert_eq!(log_b.unwrap().payload_id, payload_b.payload_id);
+    }
+
+    #[test]
+    fn test_get_validation_log_returns_none_for_unknown_payload() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SchemaEnforcer, ());
+        let client = SchemaEnforcerClient::new(&env, &contract_id);
+
+        let unknown = BytesN::<32>::from_array(&env, &[99u8; 32]);
+        assert!(client.get_validation_log(&unknown).is_none());
     }
 }


### PR DESCRIPTION
# [HIGH] Fix: `get_validation_log` permanently returned `None` — broken index

Closes #281

## Problem
`validate_payload` stored each `ValidationLog` under its `log_id` key:
```rust
env.storage().persistent().set(&log_id, &validation_log);
```
…but it **never appended `log_id` to the `validation_logs` index** that `get_validation_log` scans:
```rust
let logs_key = Symbol::new(&env, "validation_logs");
if let Some(logs) = env.storage().persistent().get::<_, Vec<BytesN<32>>>(&logs_key) {
    // index is always empty → loop never runs
}
None
```
Because the index was never populated, `get_validation_log` **always returned `None`** and every validation/audit trail was silently lost.

