### PR TITLE
fix(contracts): require admin auth in initialize() across all contracts (#282)

### DIFF
--- a/contracts/src/access_control.rs
+++ b/contracts/src/access_control.rs
@@ -107,6 +107,11 @@ impl DataSovereigntyAccessControl {
             return; // Already initialized
         }
 
+        // Require the admin to authorize initialization. Without this an
+        // attacker could front-run the deployer's setup transaction and
+        // claim admin by passing their own address.
+        admin.require_auth();
+
         // Set admin
         env.storage()
             .instance()

--- a/contracts/src/initialize_auth_tests.rs
+++ b/contracts/src/initialize_auth_tests.rs
@@ -1,0 +1,215 @@
+//! Initialization-auth coverage for issue #282.
+//!
+//! Every contract's `initialize(admin)` now calls `admin.require_auth()` so an
+//! attacker cannot front-run the deployer's setup transaction and seize admin
+//! by passing their own address. These tests assert, for all 7 contracts:
+//!
+//! * an **unsigned** `initialize` call panics with a host auth error
+//!   (`Error(Auth, InvalidAction)`), and
+//! * a **signed** `initialize` call succeeds and records the signer as admin.
+//!
+//! The unsigned/signed pair demonstrates that initialization succeeds only when
+//! the supplied admin authorizes the call.
+
+#![cfg(test)]
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, Symbol};
+
+use crate::access_control::{DataSovereigntyAccessControl, DataSovereigntyAccessControlClient};
+use crate::onchain_aggregator::{OnChainAggregator, OnChainAggregatorClient};
+use crate::privacy_oracle::{PrivacyOracle, PrivacyOracleClient};
+use crate::schema_enforcer::{SchemaEnforcer, SchemaEnforcerClient};
+use crate::stellar_analytics::{StellarAnalytics, StellarAnalyticsClient};
+use crate::ttl_storage::{TtlStorage, TtlStorageClient};
+use crate::upgradeable_proxy::{UpgradeableProxy, UpgradeableProxyClient};
+
+/// Read the admin recorded under the conventional instance-storage `admin`
+/// symbol used by the six analytics/data contracts.
+fn stored_admin(env: &Env, contract_id: &Address) -> Address {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(env, "admin"))
+            .expect("admin must be recorded after initialize")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// stellar_analytics
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn stellar_analytics_initialize_requires_admin_signature() {
+    let env = Env::default();
+    let contract_id = env.register(StellarAnalytics, ());
+    let client = StellarAnalyticsClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    // No auth mocked: the host must reject the unsigned call.
+    client.initialize(&admin);
+}
+
+#[test]
+fn stellar_analytics_initialize_succeeds_when_admin_signs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(StellarAnalytics, ());
+    let client = StellarAnalyticsClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert_eq!(stored_admin(&env, &contract_id), admin);
+}
+
+// ---------------------------------------------------------------------------
+// privacy_oracle
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn privacy_oracle_initialize_requires_admin_signature() {
+    let env = Env::default();
+    let contract_id = env.register(PrivacyOracle, ());
+    let client = PrivacyOracleClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+}
+
+#[test]
+fn privacy_oracle_initialize_succeeds_when_admin_signs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PrivacyOracle, ());
+    let client = PrivacyOracleClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert_eq!(stored_admin(&env, &contract_id), admin);
+}
+
+// ---------------------------------------------------------------------------
+// access_control
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn access_control_initialize_requires_admin_signature() {
+    let env = Env::default();
+    let contract_id = env.register(DataSovereigntyAccessControl, ());
+    let client = DataSovereigntyAccessControlClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+}
+
+#[test]
+fn access_control_initialize_succeeds_when_admin_signs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(DataSovereigntyAccessControl, ());
+    let client = DataSovereigntyAccessControlClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert_eq!(stored_admin(&env, &contract_id), admin);
+}
+
+// ---------------------------------------------------------------------------
+// ttl_storage
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn ttl_storage_initialize_requires_admin_signature() {
+    let env = Env::default();
+    let contract_id = env.register(TtlStorage, ());
+    let client = TtlStorageClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+}
+
+#[test]
+fn ttl_storage_initialize_succeeds_when_admin_signs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TtlStorage, ());
+    let client = TtlStorageClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert_eq!(stored_admin(&env, &contract_id), admin);
+}
+
+// ---------------------------------------------------------------------------
+// onchain_aggregator
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn onchain_aggregator_initialize_requires_admin_signature() {
+    let env = Env::default();
+    let contract_id = env.register(OnChainAggregator, ());
+    let client = OnChainAggregatorClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+}
+
+#[test]
+fn onchain_aggregator_initialize_succeeds_when_admin_signs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(OnChainAggregator, ());
+    let client = OnChainAggregatorClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert_eq!(stored_admin(&env, &contract_id), admin);
+}
+
+// ---------------------------------------------------------------------------
+// schema_enforcer
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn schema_enforcer_initialize_requires_admin_signature() {
+    let env = Env::default();
+    let contract_id = env.register(SchemaEnforcer, ());
+    let client = SchemaEnforcerClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+}
+
+#[test]
+fn schema_enforcer_initialize_succeeds_when_admin_signs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(SchemaEnforcer, ());
+    let client = SchemaEnforcerClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert_eq!(stored_admin(&env, &contract_id), admin);
+}
+
+// ---------------------------------------------------------------------------
+// upgradeable_proxy (initialize takes an implementation + admin and returns a
+// Result; admin is read back via the public getter)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn upgradeable_proxy_initialize_requires_admin_signature() {
+    let env = Env::default();
+    let contract_id = env.register(UpgradeableProxy, ());
+    let client = UpgradeableProxyClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let implementation = BytesN::from_array(&env, &[7u8; 32]);
+    client.initialize(&implementation, &admin);
+}
+
+#[test]
+fn upgradeable_proxy_initialize_succeeds_when_admin_signs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(UpgradeableProxy, ());
+    let client = UpgradeableProxyClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let implementation = BytesN::from_array(&env, &[7u8; 32]);
+    client.initialize(&implementation, &admin);
+    assert_eq!(client.admin(), admin);
+}

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -11,6 +11,8 @@ pub mod upgradeable_proxy;
 #[cfg(test)]
 mod access_control_tests;
 #[cfg(test)]
+mod initialize_auth_tests;
+#[cfg(test)]
 mod invariant_testing_tests;
 #[cfg(test)]
 mod onchain_aggregator_tests;

--- a/contracts/src/onchain_aggregator.rs
+++ b/contracts/src/onchain_aggregator.rs
@@ -128,6 +128,11 @@ impl OnChainAggregator {
             return; // Already initialized
         }
 
+        // Require the admin to authorize initialization. Without this an
+        // attacker could front-run the deployer's setup transaction and
+        // claim admin by passing their own address.
+        admin.require_auth();
+
         // Set admin
         env.storage()
             .instance()

--- a/contracts/src/onchain_aggregator_tests.rs
+++ b/contracts/src/onchain_aggregator_tests.rs
@@ -11,6 +11,10 @@ mod tests {
 
     /// Helper: register the contract and return the contract ID + an admin address.
     fn setup(env: &Env) -> (Address, Address) {
+        // initialize now requires the admin to authorize the call; authorize
+        // all host auth in tests so setup succeeds. Business-logic authorization
+        // (e.g. batch_process caller == admin) is unaffected and still enforced.
+        env.mock_all_auths();
         let contract_id = env.register(OnChainAggregator, ());
         let admin = Address::generate(env);
         env.as_contract(&contract_id, || {

--- a/contracts/src/privacy_oracle.rs
+++ b/contracts/src/privacy_oracle.rs
@@ -86,6 +86,11 @@ impl PrivacyOracle {
             return; // Already initialized
         }
 
+        // Require the admin to authorize initialization. Without this an
+        // attacker could front-run the deployer's setup transaction and
+        // claim admin by passing their own address.
+        admin.require_auth();
+
         // Set admin
         env.storage()
             .instance()

--- a/contracts/src/schema_enforcer.rs
+++ b/contracts/src/schema_enforcer.rs
@@ -133,6 +133,11 @@ impl SchemaEnforcer {
             return; // Already initialized
         }
 
+        // Require the admin to authorize initialization. Without this an
+        // attacker could front-run the deployer's setup transaction and
+        // claim admin by passing their own address.
+        admin.require_auth();
+
         // Set admin
         env.storage()
             .instance()

--- a/contracts/src/stellar_analytics.rs
+++ b/contracts/src/stellar_analytics.rs
@@ -120,6 +120,11 @@ impl StellarAnalytics {
             return; // Already initialized
         }
 
+        // Require the admin to authorize initialization. Without this an
+        // attacker could front-run the deployer's setup transaction and
+        // claim admin by passing their own address.
+        admin.require_auth();
+
         // Set admin
         env.storage()
             .instance()

--- a/contracts/src/ttl_storage.rs
+++ b/contracts/src/ttl_storage.rs
@@ -91,6 +91,11 @@ impl TtlStorage {
             return; // Already initialized
         }
 
+        // Require the admin to authorize initialization. Without this an
+        // attacker could front-run the deployer's setup transaction and
+        // claim admin by passing their own address.
+        admin.require_auth();
+
         // Set admin
         env.storage()
             .instance()


### PR DESCRIPTION
Closes #282

## Audit of all 7 contracts
| Contract | Before | Action |
|---|---|---|
| `stellar_analytics` | ❌ no `require_auth` | **fixed** |
| `privacy_oracle` | ❌ no `require_auth` | **fixed** |
| `access_control` | ❌ no `require_auth` | **fixed** |
| `ttl_storage` | ❌ no `require_auth` | **fixed** |
| `onchain_aggregator` | ❌ no `require_auth` | **fixed** |
| `schema_enforcer` | ❌ no `require_auth` | **fixed** |
| `upgradeable_proxy` | ✅ already had it | unchanged |
