### PR TITLE
fix(backend): implement real JWT authentication system and wire Redis (#69)

### DIFF
--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -1,28 +1,135 @@
 import request from "supertest";
 import express from "express";
 import { errorHandler } from "../middleware/errorHandler";
-import { authRoutes } from "../routes/auth";
+import jwt from "jsonwebtoken";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock database so we can test without a real Postgres connection.
+const mockQueryBuilder = {
+  insert: jest.fn().mockReturnThis(),
+  returning: jest.fn(),
+  where: jest.fn().mockReturnThis(),
+  first: jest.fn(),
+};
+
+// getDb() must return a callable function (like a real Knex instance).
+const mockDb = jest.fn(() => mockQueryBuilder);
+
+jest.mock("../config/database", () => ({
+  getDb: jest.fn(() => mockDb),
+}));
+
+// Mock Redis client – we never want real Redis in unit tests.
+jest.mock("../config/redis", () => ({
+  getRedisClient: jest.fn(() => {
+    throw new Error("Redis not initialised");
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+
+// Require AFTER mocks are set up
+const { authRoutes } = require("../routes/auth");
 
 const app = express();
 app.use(express.json());
 app.use("/api/auth", authRoutes);
 app.use(errorHandler);
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const JWT_SECRET = process.env.JWT_SECRET || "stellar-privacy-jwt-secret-dev-only";
+
+function decodeToken(token: string): any {
+  return jwt.verify(token, JWT_SECRET, { algorithms: ["HS256"] });
+}
+
 describe("Auth API Endpoints", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // POST /api/auth/register
+  // -----------------------------------------------------------------------
   describe("POST /api/auth/register", () => {
     it("should register a new user and return 201", async () => {
+      // No existing user
+      mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+      mockQueryBuilder.first.mockResolvedValueOnce(undefined); // check existing
+      mockQueryBuilder.insert.mockReturnValue(mockQueryBuilder);
+      mockQueryBuilder.returning.mockResolvedValueOnce([
+        { id: "real-user-id", email: "test@example.com", role: "user" },
+      ]);
+
       const res = await request(app)
         .post("/api/auth/register")
         .send({ email: "test@example.com", password: "password123" });
 
       expect(res.status).toBe(201);
-      expect(res.body).toHaveProperty("message");
-      expect(res.body).toHaveProperty("userId");
+      expect(res.body).toHaveProperty("message", "User registered successfully");
+      expect(res.body).toHaveProperty("userId", "real-user-id");
+      expect(res.body).toHaveProperty("email", "test@example.com");
+    });
+
+    it("should return 400 when email is missing", async () => {
+      const res = await request(app)
+        .post("/api/auth/register")
+        .send({ password: "password123" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("should return 400 when password is too short", async () => {
+      const res = await request(app)
+        .post("/api/auth/register")
+        .send({ email: "test@example.com", password: "short" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("should return 409 when user already exists", async () => {
+      mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+      mockQueryBuilder.first.mockResolvedValueOnce({
+        id: "existing-id",
+        email: "test@example.com",
+      });
+
+      const res = await request(app)
+        .post("/api/auth/register")
+        .send({ email: "test@example.com", password: "password123" });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error.code).toBe("CONFLICT");
     });
   });
 
+  // -----------------------------------------------------------------------
+  // POST /api/auth/login
+  // -----------------------------------------------------------------------
   describe("POST /api/auth/login", () => {
-    it("should login and return a token", async () => {
+    it("should login and return a valid JWT token", async () => {
+      const bcrypt = require("bcryptjs");
+      const passwordHash = await bcrypt.hash("password123", 12);
+
+      mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+      mockQueryBuilder.first.mockResolvedValueOnce({
+        id: "real-user-id",
+        email: "test@example.com",
+        password_hash: passwordHash,
+        role: "user",
+        is_active: true,
+      });
+
       const res = await request(app)
         .post("/api/auth/login")
         .send({ email: "test@example.com", password: "password123" });
@@ -30,17 +137,84 @@ describe("Auth API Endpoints", () => {
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty("token");
       expect(res.body).toHaveProperty("user");
-      expect(res.body.user).toHaveProperty("id");
-      expect(res.body.user).toHaveProperty("email");
+      expect(res.body.user).toHaveProperty("id", "real-user-id");
+      expect(res.body.user).toHaveProperty("email", "test@example.com");
+
+      // Token must be a valid HS256 JWT
+      const decoded = decodeToken(res.body.token);
+      expect(decoded.sub).toBe("real-user-id");
+      expect(decoded.email).toBe("test@example.com");
+      expect(decoded.iss).toBe("stellar-privacy");
+      expect(decoded.aud).toBe("stellar-api");
+      expect(decoded).toHaveProperty("jti");
+      expect(decoded).toHaveProperty("sessionId");
+      expect(decoded).toHaveProperty("iat");
+      expect(decoded).toHaveProperty("exp");
+    });
+
+    it("should return 401 for invalid password", async () => {
+      const bcrypt = require("bcryptjs");
+      const passwordHash = await bcrypt.hash("correct-password", 12);
+
+      mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+      mockQueryBuilder.first.mockResolvedValueOnce({
+        id: "real-user-id",
+        email: "test@example.com",
+        password_hash: passwordHash,
+        role: "user",
+        is_active: true,
+      });
+
+      const res = await request(app)
+        .post("/api/auth/login")
+        .send({ email: "test@example.com", password: "wrong-password" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should return 401 for non-existent user", async () => {
+      mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+      mockQueryBuilder.first.mockResolvedValueOnce(undefined);
+
+      const res = await request(app)
+        .post("/api/auth/login")
+        .send({ email: "unknown@example.com", password: "password123" });
+
+      expect(res.status).toBe(401);
+    });
+
+    it("should return 403 for deactivated account", async () => {
+      const bcrypt = require("bcryptjs");
+      const passwordHash = await bcrypt.hash("password123", 12);
+
+      mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+      mockQueryBuilder.first.mockResolvedValueOnce({
+        id: "deactivated-id",
+        email: "test@example.com",
+        password_hash: passwordHash,
+        role: "user",
+        is_active: false,
+      });
+
+      const res = await request(app)
+        .post("/api/auth/login")
+        .send({ email: "test@example.com", password: "password123" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe("FORBIDDEN");
     });
   });
 
+  // -----------------------------------------------------------------------
+  // POST /api/auth/logout
+  // -----------------------------------------------------------------------
   describe("POST /api/auth/logout", () => {
     it("should logout successfully", async () => {
       const res = await request(app).post("/api/auth/logout");
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty("message");
+      expect(res.body).toHaveProperty("message", "Logged out successfully");
     });
   });
 });

--- a/backend/src/gateway/PrivacyApiGateway.ts
+++ b/backend/src/gateway/PrivacyApiGateway.ts
@@ -8,6 +8,7 @@ import { RequestTransformer } from "./RequestTransformer";
 import { PrivacyMetrics } from "./PrivacyMetrics";
 import { LoadBalancer } from "./LoadBalancer";
 import { logger } from "../utils/logger";
+import jwt from "jsonwebtoken";
 
 export interface GatewayConfig {
   services: ServiceConfig[];
@@ -411,14 +412,19 @@ export class PrivacyApiGateway {
     const authHeader = req.headers.authorization;
     if (authHeader && authHeader.startsWith("Bearer ")) {
       try {
-        // In a real implementation, decode and verify JWT
         const token = authHeader.substring(7);
-        // attributes.userId = decodedToken.sub;
-        // attributes.roles = decodedToken.roles;
-        // attributes.department = decodedToken.department;
-        attributes.userId = "demo-user";
-        attributes.roles = ["analyst"];
-        attributes.department = "data-analytics";
+        // Verify with HS256 using the shared JWT secret
+        const jwtSecret = process.env.JWT_SECRET || "stellar-privacy-jwt-secret-dev-only";
+        const decoded = jwt.verify(token, jwtSecret, {
+          algorithms: ["HS256"],
+        }) as {
+          sub?: string;
+          permissions?: string[];
+          email?: string;
+        };
+        attributes.userId = decoded.sub || "unknown";
+        attributes.roles = decoded.permissions || [];
+        attributes.email = decoded.email;
       } catch (error) {
         logger.warn("Failed to decode JWT token:", error);
       }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,7 @@ import { rateLimitMonitor } from "./monitoring/rateLimitMonitor";
 
 // Import routes and middleware
 import { authRoutes } from "./routes/auth";
+import { stellarAuth } from "./middleware/stellarAuth";
 import { analyticsRoutes } from "./routes/analytics";
 import { dataRoutes, initializeUploadSocket } from "./routes/data";
 import { privacyRoutes } from "./routes/privacy";
@@ -380,6 +381,11 @@ async function initializeServices() {
   try {
     // Initialize Redis first
     await initializeRedis();
+
+    // Wire Redis into the StellarAuthMiddleware so JWT caching & revocation work
+    const redis = getRedisClient();
+    stellarAuth.setRedis(redis);
+    logger.info("Redis wired into StellarAuthMiddleware");
 
     // Initialize rate limiters
     await initializeRateLimiters();

--- a/backend/src/middleware/privacy.ts
+++ b/backend/src/middleware/privacy.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
 import { logger } from "../utils/logger";
 
 export enum PrivacyLevel {
@@ -14,6 +15,24 @@ export interface PrivacyRequest extends Request {
   consent?: boolean;
 }
 
+const JWT_SECRET = process.env.JWT_SECRET || "stellar-privacy-jwt-secret-dev-only";
+
+/**
+ * Extract the user ID from a JWT Bearer token without throwing.
+ * Returns undefined when the token is missing, expired, or malformed.
+ */
+function extractUserIdFromJwt(authHeader: string): string | undefined {
+  try {
+    const token = authHeader.substring(7);
+    const decoded = jwt.verify(token, JWT_SECRET, {
+      algorithms: ["HS256"],
+    }) as { sub?: string };
+    return decoded.sub;
+  } catch {
+    return undefined;
+  }
+}
+
 export const privacyMiddleware = (
   req: PrivacyRequest,
   res: Response,
@@ -25,11 +44,13 @@ export const privacyMiddleware = (
     ? (privacyHeader.toLowerCase() as PrivacyLevel)
     : PrivacyLevel.HIGH;
 
-  // Extract user ID from JWT (simplified for now)
+  // Extract user ID from JWT
   const authHeader = req.headers.authorization;
-  if (authHeader && authHeader.startsWith("Bearer ")) {
-    // In a real implementation, verify JWT token
-    req.userId = "temp-user-id"; // Placeholder
+  if (authHeader?.startsWith("Bearer ")) {
+    const userId = extractUserIdFromJwt(authHeader);
+    if (userId) {
+      req.userId = userId;
+    }
   }
 
   // Check consent status

--- a/backend/src/middleware/stellarAuth.ts
+++ b/backend/src/middleware/stellarAuth.ts
@@ -52,6 +52,7 @@ export interface StellarJWTPayload {
 
 export class StellarAuthMiddleware {
   private stellarPublicKey: string;
+  private jwtSecret: string;
   private apiKeySecret: string;
   private allowedIssuers: string[];
   private allowedAudiences: string[];
@@ -60,6 +61,7 @@ export class StellarAuthMiddleware {
 
   constructor(config: {
     stellarPublicKey: string;
+    jwtSecret?: string;
     apiKeySecret: string;
     redis: RedisClientType;
     allowedIssuers?: string[];
@@ -67,6 +69,7 @@ export class StellarAuthMiddleware {
     clockSkewTolerance?: number;
   }) {
     this.stellarPublicKey = config.stellarPublicKey;
+    this.jwtSecret = config.jwtSecret || process.env.JWT_SECRET || "stellar-privacy-jwt-secret-dev-only";
     this.apiKeySecret = config.apiKeySecret;
     this.redis = config.redis;
     this.allowedIssuers = config.allowedIssuers || ["stellar-privacy"];
@@ -166,12 +169,27 @@ export class StellarAuthMiddleware {
       tokenCacheMisses.inc();
 
       // 2. Verify JWT signature and claims
-      const decoded = jwt.verify(token, this.stellarPublicKey, {
-        algorithms: ["ES256"],
-        issuer: this.allowedIssuers,
-        audience: this.allowedAudiences,
-        clockTolerance: this.clockSkewTolerance,
-      }) as StellarJWTPayload;
+      //    Try ES256 (Stellar public key) first, then fall back to HS256 (shared secret).
+      let decoded: StellarJWTPayload;
+      try {
+        decoded = jwt.verify(token, this.stellarPublicKey, {
+          algorithms: ["ES256"],
+          issuer: this.allowedIssuers,
+          audience: this.allowedAudiences,
+          clockTolerance: this.clockSkewTolerance,
+        }) as StellarJWTPayload;
+      } catch (es256Error) {
+        if (this.jwtSecret && this.jwtSecret.length > 0) {
+          decoded = jwt.verify(token, this.jwtSecret, {
+            algorithms: ["HS256"],
+            issuer: this.allowedIssuers,
+            audience: this.allowedAudiences,
+            clockTolerance: this.clockSkewTolerance,
+          }) as StellarJWTPayload;
+        } else {
+          throw es256Error;
+        }
+      }
 
       // 3. Validate required claims
       this.validateJWTPayload(decoded);
@@ -340,24 +358,20 @@ export class StellarAuthMiddleware {
   }
 
   /**
-   * Look up service account for API key
+   * Look up service account for an API key.
+   *
+   * Current implementation returns a minimal service-account identity.
+   * In production, this should be backed by a dedicated `api_keys`
+   * database table with columns for key_hash, permissions, rate_limit_tier,
+   * organization_id, is_active, and expires_at.
    */
   private async lookupServiceAccount(apiKey: string): Promise<any> {
-    // This would typically query your database or cache
-    // For now, we'll return a mock service account
-
-    // In a real implementation, you would:
-    // 1. Hash the API key and look it up in your database
-    // 2. Check if the API key is active and not expired
-    // 3. Return the associated service account details
-
-    // Placeholder implementation
+    // TODO: Replace with a proper database lookup once an api_keys table exists.
     return {
-      id: "service-account-123",
-      email: "api-service@stellar-privacy.com",
-      permissions: ["read:queries", "write:queries"],
-      rateLimitTier: "enterprise" as const,
-      organizationId: "org-123",
+      id: `sa_${apiKey.substring(0, 8)}`,
+      email: `api-key@stellar-privacy.local`,
+      permissions: ["read:queries"],
+      rateLimitTier: "basic" as const,
     };
   }
 
@@ -572,6 +586,7 @@ export class StellarAuthMiddleware {
 // Factory function to create middleware instance
 export function createStellarAuth(config: {
   stellarPublicKey: string;
+  jwtSecret?: string;
   apiKeySecret: string;
   allowedIssuers?: string[];
   allowedAudiences?: string[];
@@ -583,6 +598,7 @@ export function createStellarAuth(config: {
 // Default middleware instance using environment variables
 export const stellarAuth = createStellarAuth({
   stellarPublicKey: process.env.STELLAR_PUBLIC_KEY || "",
+  jwtSecret: process.env.JWT_SECRET || "stellar-privacy-jwt-secret-dev-only",
   apiKeySecret: process.env.API_KEY_SECRET || "",
   allowedIssuers: process.env.STELLAR_ALLOWED_ISSUERS?.split(",") || [
     "stellar-privacy",

--- a/backend/src/middleware/stellarAuth.ts
+++ b/backend/src/middleware/stellarAuth.ts
@@ -57,13 +57,13 @@ export class StellarAuthMiddleware {
   private allowedIssuers: string[];
   private allowedAudiences: string[];
   private clockSkewTolerance: number;
-  private redis: RedisClientType;
+  private redis: RedisClientType | null;
 
   constructor(config: {
     stellarPublicKey: string;
     jwtSecret?: string;
     apiKeySecret: string;
-    redis: RedisClientType;
+    redis?: RedisClientType | null;
     allowedIssuers?: string[];
     allowedAudiences?: string[];
     clockSkewTolerance?: number;
@@ -71,10 +71,18 @@ export class StellarAuthMiddleware {
     this.stellarPublicKey = config.stellarPublicKey;
     this.jwtSecret = config.jwtSecret || process.env.JWT_SECRET || "stellar-privacy-jwt-secret-dev-only";
     this.apiKeySecret = config.apiKeySecret;
-    this.redis = config.redis;
+    this.redis = config.redis ?? null;
     this.allowedIssuers = config.allowedIssuers || ["stellar-privacy"];
     this.allowedAudiences = config.allowedAudiences || ["stellar-api"];
     this.clockSkewTolerance = config.clockSkewTolerance || 30; // 30 seconds
+  }
+
+  /**
+   * Set or replace the Redis client after construction.
+   * Call this at app startup once Redis is initialised.
+   */
+  setRedis(redis: RedisClientType): void {
+    this.redis = redis;
   }
 
   /**
@@ -157,35 +165,36 @@ export class StellarAuthMiddleware {
     const cacheKey = `auth:token:${tokenHash}`;
 
     try {
-      // 1. Check Cache first
-      const cachedUser = await this.redis.get(cacheKey);
-      if (cachedUser) {
-        tokenCacheHits.inc();
-        const user = JSON.parse(cachedUser);
-        this.recordAuthMetrics(startTime, "jwt", "success");
-        return user;
+      // 1. Check Cache first (Redis may not be wired yet)
+      if (this.redis) {
+        const cachedUser = await this.redis.get(cacheKey);
+        if (cachedUser) {
+          tokenCacheHits.inc();
+          const user = JSON.parse(cachedUser);
+          this.recordAuthMetrics(startTime, "jwt", "success");
+          return user;
+        }
+        tokenCacheMisses.inc();
       }
-
-      tokenCacheMisses.inc();
 
       // 2. Verify JWT signature and claims
       //    Try ES256 (Stellar public key) first, then fall back to HS256 (shared secret).
+      //    Note: issuer/audience are validated separately in validateJWTPayload
+      //    to avoid jsonwebtoken TS overload resolution issues.
       let decoded: StellarJWTPayload;
       try {
         decoded = jwt.verify(token, this.stellarPublicKey, {
           algorithms: ["ES256"],
-          issuer: this.allowedIssuers,
-          audience: this.allowedAudiences,
           clockTolerance: this.clockSkewTolerance,
-        }) as StellarJWTPayload;
+          complete: false,
+        }) as unknown as StellarJWTPayload;
       } catch (es256Error) {
         if (this.jwtSecret && this.jwtSecret.length > 0) {
           decoded = jwt.verify(token, this.jwtSecret, {
             algorithms: ["HS256"],
-            issuer: this.allowedIssuers,
-            audience: this.allowedAudiences,
             clockTolerance: this.clockSkewTolerance,
-          }) as StellarJWTPayload;
+            complete: false,
+          }) as unknown as StellarJWTPayload;
         } else {
           throw es256Error;
         }
@@ -206,14 +215,16 @@ export class StellarAuthMiddleware {
         sessionId: decoded.sessionId,
       };
 
-      // 5. Cache the result (expires when JWT expires)
-      const ttl = Math.max(0, decoded.exp - Math.floor(Date.now() / 1000));
-      if (ttl > 0) {
-        await this.redis.setEx(
-          cacheKey,
-          Math.min(ttl, 3600),
-          JSON.stringify(user),
-        ); // Max cache 1 hour
+      // 5. Cache the result (expires when JWT expires) — only when Redis is wired
+      if (this.redis) {
+        const ttl = Math.max(0, decoded.exp - Math.floor(Date.now() / 1000));
+        if (ttl > 0) {
+          await this.redis.setEx(
+            cacheKey,
+            Math.min(ttl, 3600),
+            JSON.stringify(user),
+          ); // Max cache 1 hour
+        }
       }
 
       this.recordAuthMetrics(startTime, "jwt", "success");
@@ -326,6 +337,20 @@ export class StellarAuthMiddleware {
       throw new Error("Invalid permissions in JWT");
     }
 
+    // Validate issuer
+    if (!this.allowedIssuers.includes(payload.iss)) {
+      throw new Error(
+        `JWT issuer "${payload.iss}" is not allowed`,
+      );
+    }
+
+    // Validate audience
+    if (!this.allowedAudiences.includes(payload.aud)) {
+      throw new Error(
+        `JWT audience "${payload.aud}" is not allowed`,
+      );
+    }
+
     // Check if expiration is reasonable (not too far in the future)
     const maxExpiration = Math.floor(Date.now() / 1000) + 24 * 60 * 60; // 24 hours max
     if (payload.exp > maxExpiration) {
@@ -337,6 +362,9 @@ export class StellarAuthMiddleware {
    * Check if JWT has been revoked (implement your revocation logic)
    */
   private async checkJWTRevocation(jti: string): Promise<void> {
+    if (!this.redis) {
+      return; // Redis not wired — skip revocation check
+    }
     const isRevoked = await this.redis.get(`auth:revoked:${jti}`);
     if (isRevoked) {
       throw new Error("JWT token has been revoked");
@@ -347,6 +375,10 @@ export class StellarAuthMiddleware {
    * Revoke a JWT token
    */
   async revokeToken(jti: string, expirationTimestamp: number): Promise<void> {
+    if (!this.redis) {
+      logger.warn("Cannot revoke token: Redis not wired");
+      return;
+    }
     const ttl = Math.max(
       0,
       expirationTimestamp - Math.floor(Date.now() / 1000),
@@ -588,6 +620,7 @@ export function createStellarAuth(config: {
   stellarPublicKey: string;
   jwtSecret?: string;
   apiKeySecret: string;
+  redis?: RedisClientType | null;
   allowedIssuers?: string[];
   allowedAudiences?: string[];
   clockSkewTolerance?: number;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,33 +1,219 @@
 import { Router, Request, Response } from "express";
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+import { randomBytes } from "crypto";
 import { asyncHandler } from "../middleware/errorHandler";
+import { getDb } from "../config/database";
+import { getRedisClient } from "../config/redis";
+import { logger } from "../utils/logger";
 
 const router = Router();
 
+const JWT_SECRET = process.env.JWT_SECRET || "stellar-privacy-jwt-secret-dev-only";
+const JWT_EXPIRY = process.env.JWT_EXPIRY || "1h";
+const BCRYPT_ROUNDS = 12;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateSessionId(): string {
+  return `sess_${Date.now().toString(36)}_${randomBytes(16).toString("hex")}`;
+}
+
+function generateJti(): string {
+  return `jti_${Date.now().toString(36)}_${randomBytes(12).toString("hex")}`;
+}
+
+interface UserRecord {
+  id: string;
+  email: string;
+  password_hash: string;
+  role: string;
+  is_active: boolean;
+}
+
+/**
+ * Create a signed JWT that matches the StellarJWTPayload shape expected
+ * by the StellarAuthMiddleware.
+ */
+function signJwt(user: UserRecord): string {
+  const now = Math.floor(Date.now() / 1000);
+  const exp =
+    JWT_EXPIRY.endsWith("h")
+      ? now + parseInt(JWT_EXPIRY) * 3600
+      : now + 3600;
+
+  const payload = {
+    sub: user.id,
+    email: user.email,
+    permissions: ["read:analytics", "write:queries"],
+    rateLimitTier: "basic" as const,
+    sessionId: generateSessionId(),
+    iat: now,
+    exp,
+    jti: generateJti(),
+    iss: "stellar-privacy",
+    aud: "stellar-api",
+  };
+
+  return jwt.sign(payload, JWT_SECRET, { algorithm: "HS256" });
+}
+
+/**
+ * Attempt to add a JTI to the Redis revocation set. Fails gracefully when
+ * Redis is not available (e.g. in unit tests).
+ */
+async function addToRevocationList(jti: string, exp: number): Promise<void> {
+  try {
+    const redis = getRedisClient();
+    const ttl = Math.max(0, exp - Math.floor(Date.now() / 1000));
+    if (ttl > 0) {
+      await redis.set(`auth:revoked:${jti}`, "1", { EX: ttl });
+    }
+  } catch {
+    // Redis may not be initialised in all environments (e.g. tests)
+    logger.warn("Could not write JWT revocation to Redis (client unavailable)");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
 router.post(
   "/register",
-  asyncHandler(async (_req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
+    const { email, password } = req.body;
+
+    // --- validation ---
+    if (!email || !password) {
+      return res.status(400).json({
+        error: { code: "BAD_REQUEST", message: "Email and password are required" },
+      });
+    }
+    if (typeof password !== "string" || password.length < 8) {
+      return res.status(400).json({
+        error: {
+          code: "BAD_REQUEST",
+          message: "Password must be at least 8 characters",
+        },
+      });
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return res.status(400).json({
+        error: { code: "BAD_REQUEST", message: "Invalid email format" },
+      });
+    }
+
+    const db = getDb();
+
+    // --- check for existing user ---
+    const existing = await db("users").where({ email }).first();
+    if (existing) {
+      return res.status(409).json({
+        error: { code: "CONFLICT", message: "A user with this email already exists" },
+      });
+    }
+
+    // --- hash password & persist ---
+    const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+    const [newUser] = await db("users")
+      .insert({
+        email,
+        password_hash: passwordHash,
+        role: "user",
+        is_active: true,
+      })
+      .returning(["id", "email", "role"]);
+
+    logger.info("User registered", { userId: newUser.id, email });
+
     res.status(201).json({
       message: "User registered successfully",
-      userId: "temp-user-id",
+      userId: newUser.id,
+      email: newUser.email,
     });
-  })
+  }),
 );
 
 router.post(
   "/login",
-  asyncHandler(async (_req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
+    const { email, password } = req.body;
+
+    if (!email || !password) {
+      return res.status(400).json({
+        error: { code: "BAD_REQUEST", message: "Email and password are required" },
+      });
+    }
+
+    const db = getDb();
+    const user: UserRecord | undefined = await db("users")
+      .where({ email })
+      .first();
+
+    if (!user) {
+      return res.status(401).json({
+        error: { code: "UNAUTHORIZED", message: "Invalid email or password" },
+      });
+    }
+
+    if (!user.is_active) {
+      return res.status(403).json({
+        error: { code: "FORBIDDEN", message: "Account is deactivated" },
+      });
+    }
+
+    const passwordValid = await bcrypt.compare(password, user.password_hash);
+    if (!passwordValid) {
+      return res.status(401).json({
+        error: { code: "UNAUTHORIZED", message: "Invalid email or password" },
+      });
+    }
+
+    const token = signJwt(user);
+
+    logger.info("User logged in", { userId: user.id, email });
+
     res.json({
-      token: "temp-jwt-token",
-      user: { id: "temp-user-id", email: "user@example.com" },
+      token,
+      user: {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        permissions: ["read:analytics", "write:queries"],
+        rateLimitTier: "basic",
+      },
     });
-  })
+  }),
 );
 
 router.post(
   "/logout",
-  asyncHandler(async (_req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
+    const authHeader = req.headers.authorization;
+
+    if (authHeader?.startsWith("Bearer ")) {
+      const token = authHeader.substring(7);
+      try {
+        const decoded = jwt.verify(token, JWT_SECRET, {
+          algorithms: ["HS256"],
+          ignoreExpiration: true, // allow revoking expired tokens too
+        }) as { jti?: string; exp?: number };
+
+        if (decoded.jti && decoded.exp) {
+          await addToRevocationList(decoded.jti, decoded.exp);
+          logger.info("Token revoked on logout", { jti: decoded.jti });
+        }
+      } catch {
+        // Token is malformed – nothing to revoke
+      }
+    }
+
     res.json({ message: "Logged out successfully" });
-  })
+  }),
 );
 
 export { router as authRoutes };


### PR DESCRIPTION
## Summary

Implements a real JWT authentication system for the backend:

- **Auth routes** (/api/auth): Register, login, and logout with bcrypt password hashing and HS256 JWT signing
- **StellarAuthMiddleware**: JWT + API key authentication with Redis-backed caching and revocation, plus permission/rate-limit-tier/organization authorization guards
- **Redis wiring**: Made Redis optional in the middleware with late-binding via setRedis(), wired at app startup in index.ts
- **Type fixes**: Resolved jsonwebtoken TS overload issues by moving issuer/audience validation into validateJWTPayload

### Changes
- backend/src/routes/auth.ts — Register, login, logout endpoints
- backend/src/middleware/stellarAuth.ts — Full StellarAuthMiddleware class
- backend/src/__tests__/auth.test.ts — 9 passing unit tests
- backend/src/index.ts — Redis wiring into stellarAuth at startup
- backend/src/gateway/PrivacyApiGateway.ts — JWT extraction for gateway
- backend/src/middleware/privacy.ts — JWT user ID extraction

Closes #69