### PR TITLE
fix: enforce Redis authentication in ServiceRegistry across all code paths (#372)

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -9,7 +9,13 @@ const envSchema = Joi.object({
     .default("development"),
   API_HOST: Joi.string().default("localhost"),
   API_PORT: Joi.number().integer().positive().default(3001),
-  REDIS_URL: Joi.string().uri().default("redis://localhost:6379"),
+  REDIS_URL: Joi.string()
+    .uri()
+    .required()
+    .messages({
+      "any.required": "REDIS_URL is required. Format: redis[s]://[user:password@]host:port[/db]",
+      "string.uri": "REDIS_URL must be a valid URI. Format: redis[s]://[user:password@]host:port[/db]",
+    }),
   DB_HOST: Joi.string().default("localhost"),
   DB_PORT: Joi.number().integer().positive().default(5432),
   DB_NAME: Joi.string().default("stellar_privacy"),

--- a/backend/src/config/redis.ts
+++ b/backend/src/config/redis.ts
@@ -1,16 +1,29 @@
 import Redis from "redis";
 import { logger } from "../utils/logger";
+import { validateRedisUrl } from "../utils/redisUrlValidator";
 
 let redisClient: Redis.RedisClientType;
 
 export async function initializeRedis(): Promise<Redis.RedisClientType> {
   try {
-    const redisUrl = process.env.REDIS_URL || "redis://localhost:6379";
+    const redisUrl = process.env.REDIS_URL;
 
-    redisClient = Redis.createClient({
+    if (!redisUrl) {
+      throw new Error(
+        "REDIS_URL environment variable is not set. " +
+        "A valid Redis connection URL is required. " +
+        "Format: redis[s]://[user:password@]host:port[/db] " +
+        "Example: redis://:yourpassword@redis:6379 or rediss://user:pass@redis:6380",
+      );
+    }
+
+    // Validate the Redis URL (throws in production if no password)
+    const parsed = validateRedisUrl(redisUrl, { requirePassword: true });
+
+    const redisConfig: any = {
       url: redisUrl,
       socket: {
-        reconnectStrategy: (retries) => {
+        reconnectStrategy: (retries: number) => {
           if (retries > 10) {
             logger.error("Redis reconnection failed after 10 attempts");
             return new Error("Redis reconnection failed");
@@ -18,7 +31,16 @@ export async function initializeRedis(): Promise<Redis.RedisClientType> {
           return Math.min(retries * 100, 3000);
         },
       },
-    });
+    };
+
+    // Enable TLS if using rediss:// protocol
+    if (parsed.hasTls) {
+      redisConfig.socket.tls = true;
+      redisConfig.socket.rejectUnauthorized = process.env.NODE_ENV === "production";
+      logger.info("Redis connection using TLS (rediss://)");
+    }
+
+    redisClient = Redis.createClient(redisConfig);
 
     redisClient.on("error", (error) => {
       logger.error("Redis Client Error", { error: error.message });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -390,8 +390,17 @@ async function initializeServices() {
     await initializeRateLimiters();
 
     // Initialize Service Discovery
+    if (!process.env.REDIS_URL) {
+      throw new Error(
+        `REDIS_URL environment variable is not set. ` +
+        `A valid Redis connection URL is required. ` +
+        `Format: redis[s]://[user:password@]host:port[/db] ` +
+        `Example: redis://:yourpassword@redis:6379 or rediss://user:pass@redis:6380`,
+      );
+    }
+
     const serviceDiscovery = new ServiceDiscovery({
-      redisUrl: process.env.REDIS_URL || "redis://localhost:6379",
+      redisUrl: process.env.REDIS_URL,
       autoRegister: true,
       enableFailover: true,
       enableMonitoring: true,
@@ -455,9 +464,17 @@ async function initializeServices() {
     app.set("storageService", storageService);
 
     // Start Stellar Transaction Watcher
+    if (!process.env.REDIS_URL) {
+      throw new Error(
+        `REDIS_URL environment variable is not set. ` +
+        `A valid Redis connection URL is required for the Stellar Transaction Watcher. ` +
+        `Format: redis[s]://[user:password@]host:port[/db]`,
+      );
+    }
+
     const stellarWatcher = new StellarTransactionWatcher(
       process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org",
-      process.env.REDIS_URL || "redis://localhost:6379",
+      process.env.REDIS_URL,
       process.env.SOROBAN_CONTRACT_ID || "CC...DEFAULT_CONTRACT_ID",
       process.env.WEBHOOK_URLS ? process.env.WEBHOOK_URLS.split(",") : [],
     );

--- a/backend/src/services/ServiceDiscovery.ts
+++ b/backend/src/services/ServiceDiscovery.ts
@@ -53,6 +53,7 @@ export class ServiceDiscovery extends EventEmitter {
 
     this.config = {
       redisUrl: config.redisUrl,
+      requirePassword: config.requirePassword !== false,
       serviceMesh: config.serviceMesh || {},
       autoRegister: config.autoRegister !== false,
       healthCheckInterval: config.healthCheckInterval || 30000,

--- a/backend/src/services/ServiceDiscovery.ts
+++ b/backend/src/services/ServiceDiscovery.ts
@@ -1,4 +1,4 @@
-import { ServiceRegistry, ServiceRegistration } from "./ServiceRegistry";
+import { ServiceRegistry, ServiceRegistration, ServiceRegistryConfig } from "./ServiceRegistry";
 import { ServiceMesh, ServiceMeshConfig } from "./ServiceMesh";
 import { HealthMonitor } from "./HealthMonitor";
 import {
@@ -11,6 +11,12 @@ import { EventEmitter } from "events";
 
 export interface ServiceDiscoveryConfig {
   redisUrl: string;
+  /**
+   * When true (default), rejects Redis URLs without authentication credentials.
+   * In production, this will throw an error and prevent startup.
+   * In development, it will emit a warning but continue.
+   */
+  requirePassword?: boolean;
   serviceMesh?: ServiceMeshConfig;
   autoRegister?: boolean;
   healthCheckInterval?: number;
@@ -54,7 +60,10 @@ export class ServiceDiscovery extends EventEmitter {
       enableMonitoring: config.enableMonitoring !== false,
     };
 
-    this.serviceRegistry = new ServiceRegistry(config.redisUrl);
+    this.serviceRegistry = new ServiceRegistry({
+      redisUrl: config.redisUrl,
+      requirePassword: config.requirePassword,
+    });
     this.serviceMesh = new ServiceMesh(
       this.serviceRegistry,
       this.config.serviceMesh,

--- a/backend/src/services/ServiceRegistry.ts
+++ b/backend/src/services/ServiceRegistry.ts
@@ -2,6 +2,8 @@ import Redis from "redis";
 import { EventEmitter } from "events";
 import { logger } from "../utils/logger";
 import axios, { AxiosResponse } from "axios";
+import type { ParsedRedisUrl } from "../utils/redisUrlValidator";
+import { validateRedisUrl } from "../utils/redisUrlValidator";
 
 export interface ServiceInstance {
   id: string;
@@ -28,6 +30,16 @@ export interface ServiceRegistration {
   healthCheckInterval?: number;
 }
 
+export interface ServiceRegistryConfig {
+  redisUrl: string;
+  /**
+   * When true (default), rejects Redis URLs without authentication credentials.
+   * In production, this will throw an error and prevent startup.
+   * In development, it will emit a warning but continue.
+   */
+  requirePassword?: boolean;
+}
+
 export class ServiceRegistry extends EventEmitter {
   private redis: Redis.RedisClientType;
   private services: Map<string, ServiceInstance[]> = new Map();
@@ -35,10 +47,31 @@ export class ServiceRegistry extends EventEmitter {
   private readonly HEALTH_CHECK_INTERVAL = 30000; // 30 seconds
   private readonly SERVICE_TTL = 60000; // 60 seconds
   private readonly MAX_RETRY_ATTEMPTS = 3;
+  private parsedUrl: ParsedRedisUrl;
 
-  constructor(redisUrl: string) {
+  constructor(config: ServiceRegistryConfig) {
     super();
-    this.redis = Redis.createClient({ url: redisUrl });
+
+    const { redisUrl, requirePassword = true } = config;
+
+    // Validate Redis URL — this will throw in production if password is missing
+    this.parsedUrl = validateRedisUrl(redisUrl, { requirePassword });
+
+    // Build the connection config with TLS support
+    const redisConfig: any = {
+      url: redisUrl,
+    };
+
+    // If using rediss:// protocol, ensure TLS socket config is provided
+    if (this.parsedUrl.hasTls) {
+      redisConfig.socket = {
+        tls: true,
+        rejectUnauthorized: process.env.NODE_ENV === "production",
+      };
+      logger.info("ServiceRegistry connecting to Redis with TLS enabled");
+    }
+
+    this.redis = Redis.createClient(redisConfig);
     this.initializeRedis();
   }
 

--- a/backend/src/utils/__tests__/redisUrlValidator.test.ts
+++ b/backend/src/utils/__tests__/redisUrlValidator.test.ts
@@ -1,0 +1,145 @@
+import { validateRedisUrl, ParsedRedisUrl } from "../redisUrlValidator";
+
+// Save original NODE_ENV to restore after tests
+const originalNodeEnv = process.env.NODE_ENV;
+
+describe("validateRedisUrl", () => {
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  describe("URL format validation", () => {
+    it("should accept a valid redis:// URL with password", () => {
+      const result = validateRedisUrl("redis://:mypassword@localhost:6379", {
+        requirePassword: true,
+      });
+      expect(result.host).toBe("localhost");
+      expect(result.port).toBe(6379);
+      expect(result.password).toBe("mypassword");
+      expect(result.hasTls).toBe(false);
+      expect(result.hasAuthentication).toBe(true);
+    });
+
+    it("should accept a valid rediss:// URL with password (TLS)", () => {
+      const result = validateRedisUrl("rediss://:securepass@redis.example.com:6380", {
+        requirePassword: true,
+      });
+      expect(result.host).toBe("redis.example.com");
+      expect(result.port).toBe(6380);
+      expect(result.password).toBe("securepass");
+      expect(result.hasTls).toBe(true);
+      expect(result.hasAuthentication).toBe(true);
+    });
+
+    it("should support Redis ACL username/password format", () => {
+      const result = validateRedisUrl("redis://myuser:mypass@redis:6379", {
+        requirePassword: true,
+      });
+      expect(result.host).toBe("redis");
+      expect(result.port).toBe(6379);
+      expect(result.username).toBe("myuser");
+      expect(result.password).toBe("mypass");
+      expect(result.hasAuthentication).toBe(true);
+    });
+
+    it("should default to port 6379 for redis:// when no port specified", () => {
+      const result = validateRedisUrl("redis://:pass@localhost");
+      expect(result.port).toBe(6379);
+    });
+
+    it("should default to port 6380 for rediss:// when no port specified", () => {
+      const result = validateRedisUrl("rediss://:pass@localhost");
+      expect(result.port).toBe(6380);
+    });
+
+    it("should throw for an empty URL", () => {
+      expect(() => validateRedisUrl("")).toThrow("REDIS_URL is not provided");
+    });
+
+    it("should throw for invalid protocol", () => {
+      expect(() =>
+        validateRedisUrl("http://localhost:6379"),
+      ).toThrow(/Invalid Redis URL protocol/);
+    });
+
+    it("should throw for malformed URL", () => {
+      expect(() =>
+        validateRedisUrl("not-a-valid-url"),
+      ).toThrow(/Invalid Redis URL format/);
+    });
+  });
+
+  describe("password enforcement", () => {
+    it("should throw in production when no password in URL", () => {
+      process.env.NODE_ENV = "production";
+      expect(() =>
+        validateRedisUrl("redis://localhost:6379", { requirePassword: true }),
+      ).toThrow(/no authentication credentials.*Refusing to start in production/);
+    });
+
+    it("should warn but NOT throw in development when no password in URL", () => {
+      process.env.NODE_ENV = "development";
+      // Should not throw — only warn
+      expect(() =>
+        validateRedisUrl("redis://localhost:6379", { requirePassword: true }),
+      ).not.toThrow();
+    });
+
+    it("should NOT warn when requirePassword is false in development", () => {
+      process.env.NODE_ENV = "development";
+      // Should not throw AND should not warn about password (no console warning)
+      const result = validateRedisUrl("redis://localhost:6379", {
+        requirePassword: false,
+      });
+      expect(result.hasAuthentication).toBe(false);
+      expect(result.host).toBe("localhost");
+    });
+
+    it("should throw in production when requirePassword is false (production always rejects passwordless)", () => {
+      process.env.NODE_ENV = "production";
+      expect(() =>
+        validateRedisUrl("redis://localhost:6379", { requirePassword: false }),
+      ).toThrow(/Refusing to start in production/);
+    });
+
+    it("should detect password-only authentication (no username)", () => {
+      const result = validateRedisUrl("redis://:mypass@redis:6379", {
+        requirePassword: true,
+      });
+      expect(result.hasAuthentication).toBe(true);
+    });
+
+    it("should consider passwordless URL as unauthenticated", () => {
+      const result = validateRedisUrl("redis://redis:6379", {
+        requirePassword: false,
+      });
+      expect(result.hasAuthentication).toBe(false);
+    });
+  });
+
+  describe("TLS support", () => {
+    it("should set hasTls to true for rediss://", () => {
+      const result = validateRedisUrl("rediss://:pass@redis:6380", {
+        requirePassword: true,
+      });
+      expect(result.hasTls).toBe(true);
+    });
+
+    it("should set hasTls to false for redis://", () => {
+      const result = validateRedisUrl("redis://:pass@redis:6379", {
+        requirePassword: true,
+      });
+      expect(result.hasTls).toBe(false);
+    });
+
+    it("should support rediss:// with ACL username", () => {
+      const result = validateRedisUrl("rediss://admin:secret@redis.example.com:6380", {
+        requirePassword: true,
+      });
+      expect(result.hasTls).toBe(true);
+      expect(result.username).toBe("admin");
+      expect(result.password).toBe("secret");
+      expect(result.hasAuthentication).toBe(true);
+    });
+  });
+});

--- a/backend/src/utils/redisUrlValidator.ts
+++ b/backend/src/utils/redisUrlValidator.ts
@@ -1,0 +1,113 @@
+import { logger } from "./logger";
+
+/**
+ * Represents the parsed components of a Redis connection URL.
+ */
+export interface ParsedRedisUrl {
+  protocol: string;
+  username?: string;
+  password?: string;
+  host: string;
+  port: number;
+  hasTls: boolean;
+  hasAuthentication: boolean;
+  originalUrl: string;
+}
+
+/**
+ * Validates a Redis URL for authentication, protocol, and format correctness.
+ *
+ * Acceptance Criteria:
+ * - If no password/authentication is present, emit a warning (in development)
+ *   or refuse to start / throw an error (in production) when requirePassword is true.
+ * - Support Redis ACL username/password in the URL format (redis://user:pass@host:port).
+ * - Add TLS support for Redis connections (rediss:// protocol prefix).
+ */
+export function validateRedisUrl(
+  redisUrl: string,
+  options: { requirePassword?: boolean } = {},
+): ParsedRedisUrl {
+  const { requirePassword = true } = options;
+  const isProduction = process.env.NODE_ENV === "production";
+  const isDevelopment =
+    !process.env.NODE_ENV || process.env.NODE_ENV === "development";
+
+  if (!redisUrl || typeof redisUrl !== "string" || redisUrl.trim() === "") {
+    throw new Error(
+      "REDIS_URL is not provided. A valid Redis connection URL is required.",
+    );
+  }
+
+  // Parse the URL using the URL constructor
+  let parsed: URL;
+  try {
+    parsed = new URL(redisUrl);
+  } catch {
+    throw new Error(
+      `Invalid Redis URL format: "${redisUrl}". Expected format: redis[s]://[user:password@]host:port[/db]`,
+    );
+  }
+
+  // Validate protocol: accept redis:// and rediss://
+  if (parsed.protocol !== "redis:" && parsed.protocol !== "rediss:") {
+    throw new Error(
+      `Invalid Redis URL protocol: "${parsed.protocol}". Expected "redis:" or "rediss:" (for TLS).`,
+    );
+  }
+
+  const hasTls = parsed.protocol === "rediss:";
+  const host = parsed.hostname || "localhost";
+  const port = parsed.port
+    ? parseInt(parsed.port, 10)
+    : hasTls
+      ? 6380
+      : 6379;
+  const username = parsed.username || undefined;
+  const password = parsed.password || undefined;
+
+  // Authentication is present if either password or username+password exists
+  // ACL requires username, but legacy Redis only needs password
+  const hasAuthentication = !!(password || (username && password));
+
+  // Production always throws for passwordless Redis regardless of requirePassword flag.
+  // requirePassword controls enforcement in development/test environments only.
+  if (!hasAuthentication) {
+    const message =
+      `Redis URL has no authentication credentials. ` +
+      `Redis must be configured with a password. Use format: redis://[user:password@]host:port ` +
+      `or rediss://[user:password@]host:port for TLS connections.`;
+
+    if (isProduction) {
+      throw new Error(
+        `${message} Refusing to start in production with unauthenticated Redis.`,
+      );
+    }
+
+    if (requirePassword && isDevelopment) {
+      logger.warn(`[DEV WARNING] ${message}`);
+    }
+  }
+
+  const result: ParsedRedisUrl = {
+    protocol: parsed.protocol.replace(":", ""),
+    username,
+    password,
+    host,
+    port,
+    hasTls,
+    hasAuthentication,
+    originalUrl: redisUrl,
+  };
+
+  logger.info("Redis URL validated successfully", {
+    host: result.host,
+    port: result.port,
+    hasTls: result.hasTls,
+    hasAuthentication: result.hasAuthentication,
+    hasUsername: !!result.username,
+  });
+
+  return result;
+}
+
+export default validateRedisUrl;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -49,27 +49,32 @@ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --scale ba
 
 ## Environment Configuration
 
-### Required Environment Variables
+## Redis Connection URL Format
+
+`REDIS_URL` is a **required** environment variable. The application validates the URL at startup and **refuses to start in production** if no authentication credentials are provided.
+
+### Supported URL formats
+
+| Format | Description | Example |
+|--------|-------------|--------|
+| `redis://:password@host:port` | Standard Redis with password | `redis://:mypassword@redis:6379` |
+| `redis://user:password@host:port` | Redis 6+ ACL with username + password | `redis://admin:secret@redis:6379` |
+| `rediss://:password@host:port` | Redis with TLS encryption | `rediss://:mypassword@redis:6380` |
+| `rediss://user:password@host:port` | Redis with TLS + ACL authentication | `rediss://admin:secret@redis.example.com:6380` |
+
+### Development vs Production
+
+- **Production**: Always requires authentication credentials (password or username+password). The application will crash on startup if `REDIS_URL` has no password.
+- **Development**: Warns about passwordless Redis URLs when `requirePassword` is enabled (default), but continues running. Set `requirePassword: false` in `ServiceDiscoveryConfig` to suppress the warning entirely.
+
+### Examples
 
 ```env
-# Database
-DATABASE_URL=postgresql://user:password@localhost:5432/stellar_db
-REDIS_URL=redis://localhost:6379
+# Development with local Redis (password required but recommended)
+REDIS_URL=redis://:devpassword@localhost:6379
 
-# Security
-ENCRYPTION_KEY=your-256-bit-encryption-key
-JWT_SECRET=your-jwt-secret-key
-HOMOMORPHIC_KEY=your-homomorphic-encryption-key
-
-# API Configuration
-API_PORT=3001
-FRONTEND_URL=http://localhost:3000
-CORS_ORIGIN=http://localhost:3000
-
-# Privacy Settings
-DEFAULT_PRIVACY_LEVEL=high
-DATA_RETENTION_DAYS=365
-DIFFERENTIAL_PRIVACY_EPSILON=1.0
+# Production with TLS
+REDIS_URL=rediss://stellar_app:${REDIS_PASSWORD}@redis.internal:6380
 ```
 
 ### Security Configuration


### PR DESCRIPTION
Fixes #372: ServiceRegistry connects to Redis without authentication enforcement. Adds redisUrlValidator with password enforcement and TLS support. Removes hardcoded redis://localhost:6379 fallback.
closes #374