### PR TITLE
fix: secure admin rate-limit endpoints with auth in all environments (#369)

### DIFF
--- a/backend/src/__tests__/admin-rate-limit.test.ts
+++ b/backend/src/__tests__/admin-rate-limit.test.ts
@@ -1,0 +1,276 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock Redis client – we never want real Redis in unit tests.
+jest.mock("../config/redis", () => ({
+  getRedisClient: jest.fn(() => {
+    throw new Error("Redis not initialised");
+  }),
+  initializeRedis: jest.fn(),
+}));
+
+// Mock rateLimitMonitor so we can test without real monitoring
+jest.mock("../monitoring/rateLimitMonitor", () => ({
+  rateLimitMonitor: {
+    getMetricsSummary: jest.fn(() => ({
+      current: {
+        totalRequests: 100,
+        blockedRequests: 5,
+        bypassedRequests: 0,
+        averageRequestRate: 2.5,
+        peakRequestRate: 10,
+        collisionCount: 0,
+        adaptiveAdjustments: 0,
+      },
+      alerts: [],
+      trends: {
+        blockRate: 0.05,
+        collisionRate: 0,
+        adaptiveRate: 0,
+      },
+    })),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import the real admin routes (not a duplicated copy)
+// ---------------------------------------------------------------------------
+import { adminRoutes } from "../routes/admin";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const JWT_SECRET = process.env.JWT_SECRET || "stellar-privacy-jwt-secret-dev-only";
+
+function createAdminToken(): string {
+  return jwt.sign(
+    {
+      sub: "admin-user-1",
+      email: "admin@stellar-privacy.local",
+      permissions: ["admin:access", "read:analytics"],
+      rateLimitTier: "enterprise",
+      sessionId: "session-admin-1",
+      jti: `jti-admin-${Date.now()}`,
+      iss: "stellar-privacy",
+      aud: "stellar-api",
+    },
+    JWT_SECRET,
+    {
+      algorithm: "HS256",
+      expiresIn: "1h",
+    },
+  );
+}
+
+function createNonAdminToken(): string {
+  return jwt.sign(
+    {
+      sub: "regular-user-1",
+      email: "user@stellar-privacy.local",
+      permissions: ["read:analytics"],
+      rateLimitTier: "basic",
+      sessionId: "session-user-1",
+      jti: `jti-user-${Date.now()}`,
+      iss: "stellar-privacy",
+      aud: "stellar-api",
+    },
+    JWT_SECRET,
+    {
+      algorithm: "HS256",
+      expiresIn: "1h",
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test App
+// ---------------------------------------------------------------------------
+
+function createTestApp(): express.Application {
+  const app = express();
+  app.use("/api/v1/admin", adminRoutes);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Admin Rate-Limit Endpoints", () => {
+  let app: express.Application;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    app = createTestApp();
+    delete process.env.DEV_ADMIN_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    delete process.env.DEV_ADMIN_TOKEN;
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/admin/rate-limit/metrics
+  // -----------------------------------------------------------------------
+  describe("GET /api/v1/admin/rate-limit/metrics", () => {
+    it("should return 401 for unauthenticated request", async () => {
+      const res = await request(app).get("/api/v1/admin/rate-limit/metrics");
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+    });
+
+    it("should return 401 for request with no auth headers", async () => {
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/metrics")
+        .set("X-Custom-Header", "value");
+
+      expect(res.status).toBe(401);
+    });
+
+    it("should return 403 for authenticated non-admin user", async () => {
+      const token = createNonAdminToken();
+
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/metrics")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("Admin access required");
+    });
+
+    it("should return 200 with metrics for authenticated admin user", async () => {
+      const token = createAdminToken();
+
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/metrics")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("metrics");
+      expect(res.body).toHaveProperty("timestamp");
+      expect(res.body).toHaveProperty("environment");
+      expect(res.body.metrics).toHaveProperty("current");
+      expect(res.body.metrics).toHaveProperty("alerts");
+      expect(res.body.metrics).toHaveProperty("trends");
+    });
+
+    it("should allow dev admin token access when DEV_ADMIN_TOKEN is set", async () => {
+      process.env.DEV_ADMIN_TOKEN = "dev-secret-token-12345";
+
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/metrics")
+        .set("Authorization", "Bearer dev-secret-token-12345");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("metrics");
+    });
+
+    it("should reject invalid dev admin token", async () => {
+      process.env.DEV_ADMIN_TOKEN = "dev-secret-token-12345";
+
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/metrics")
+        .set("Authorization", "Bearer wrong-token");
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/admin/rate-limit/config
+  // -----------------------------------------------------------------------
+  describe("GET /api/v1/admin/rate-limit/config", () => {
+    it("should return 401 for unauthenticated request", async () => {
+      const res = await request(app).get("/api/v1/admin/rate-limit/config");
+
+      expect(res.status).toBe(401);
+    });
+
+    it("should return 403 for authenticated non-admin user", async () => {
+      const token = createNonAdminToken();
+
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/config")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("Admin access required");
+    });
+
+    it("should return 200 with config for authenticated admin user", async () => {
+      const token = createAdminToken();
+
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/config")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("config");
+      expect(res.body).toHaveProperty("timestamp");
+      expect(res.body.config).toHaveProperty("standard");
+      expect(res.body.config).toHaveProperty("enhanced");
+      expect(res.body.config).toHaveProperty("monitoring");
+    });
+
+    it("should allow dev admin token access to config when DEV_ADMIN_TOKEN is set", async () => {
+      process.env.DEV_ADMIN_TOKEN = "dev-config-token";
+
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/config")
+        .set("Authorization", "Bearer dev-config-token");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("config");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cross-environment behavior
+  // -----------------------------------------------------------------------
+  describe("auth enforcement in all environments", () => {
+    it("should require authentication even when NODE_ENV is development", async () => {
+      process.env.NODE_ENV = "development";
+
+      const res = await request(app).get("/api/v1/admin/rate-limit/metrics");
+
+      // In development without DEV_ADMIN_TOKEN, still requires auth
+      expect(res.status).toBe(401);
+    });
+
+    it("should require authentication in test environment", async () => {
+      process.env.NODE_ENV = "test";
+
+      const res = await request(app).get("/api/v1/admin/rate-limit/metrics");
+
+      expect(res.status).toBe(401);
+    });
+
+    it("should not allow unauthenticated access in production", async () => {
+      process.env.NODE_ENV = "production";
+
+      const res = await request(app).get("/api/v1/admin/rate-limit/metrics");
+
+      expect(res.status).toBe(401);
+    });
+
+    it("should not accept DEV_ADMIN_TOKEN in production", async () => {
+      process.env.NODE_ENV = "production";
+      process.env.DEV_ADMIN_TOKEN = "should-not-work-in-prod";
+
+      const res = await request(app)
+        .get("/api/v1/admin/rate-limit/metrics")
+        .set("Authorization", "Bearer should-not-work-in-prod");
+
+      // In production, dev token should NOT work — should get 401
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -24,6 +24,7 @@ const envSchema = Joi.object({
   CORS_ORIGINS: Joi.string().default(
     "http://localhost:3000,http://localhost:3001",
   ),
+  DEV_ADMIN_TOKEN: Joi.string().allow("").optional(),
 }).unknown(true);
 
 const { value, error } = envSchema.validate(process.env, {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import { rateLimitMonitor } from "./monitoring/rateLimitMonitor";
 // Import routes and middleware
 import { authRoutes } from "./routes/auth";
 import { stellarAuth } from "./middleware/stellarAuth";
+import { adminRoutes } from "./routes/admin";
 import { analyticsRoutes } from "./routes/analytics";
 import { dataRoutes, initializeUploadSocket } from "./routes/data";
 import { privacyRoutes } from "./routes/privacy";
@@ -191,49 +192,8 @@ app.use("/api/v1", async (req, res, next) => {
   next();
 });
 
-// Rate limiting monitoring endpoint
-app.get("/api/v1/admin/rate-limit/metrics", (req, res) => {
-  if (process.env.NODE_ENV === "production" && !(req as any).user?.isAdmin) {
-    return res.status(403).json({ error: "Admin access required" });
-  }
-
-  const metrics = rateLimitMonitor.getMetricsSummary();
-  res.json({
-    metrics,
-    timestamp: new Date().toISOString(),
-    environment: process.env.NODE_ENV || "development",
-  });
-});
-
-// Rate limiting configuration endpoint
-app.get("/api/v1/admin/rate-limit/config", (req, res) => {
-  if (process.env.NODE_ENV === "production" && !(req as any).user?.isAdmin) {
-    return res.status(403).json({ error: "Admin access required" });
-  }
-
-  res.json({
-    config: {
-      standard: {
-        windowMs: 15 * 60 * 1000,
-        basic: { maxRequests: 100 },
-        premium: { maxRequests: 500 },
-        enterprise: { maxRequests: 2000 },
-      },
-      enhanced: {
-        collisionDetection: true,
-        burstProtection: true,
-        adaptiveLimiting: true,
-        alerting: true,
-      },
-      monitoring: {
-        enabled: true,
-        interval: 30000,
-        retention: 24 * 60 * 60 * 1000,
-      },
-    },
-    timestamp: new Date().toISOString(),
-  });
-});
+// Admin routes (rate-limit metrics & config) with admin auth middleware
+app.use("/api/v1/admin", adminRoutes);
 
 // Health check endpoint
 app.get("/health", (req, res) => {

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,84 @@
+import express from "express";
+import { stellarAuth } from "../middleware/stellarAuth";
+import { rateLimitMonitor } from "../monitoring/rateLimitMonitor";
+
+/**
+ * Admin authentication middleware.
+ *
+ * Requires JWT/API-key authentication in **all** environments.
+ * In non-production, the DEV_ADMIN_TOKEN env var can be used as a bearer
+ * token to skip full JWT verification for local development convenience.
+ */
+export const adminAuth = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): Promise<void> => {
+  // Dev admin token bypass (non-production only)
+  if (process.env.NODE_ENV !== "production") {
+    const devToken = process.env.DEV_ADMIN_TOKEN;
+    if (devToken) {
+      const authHeader = req.headers.authorization;
+      if (authHeader === `Bearer ${devToken}`) {
+        (req as any).user = {
+          id: "dev-admin",
+          email: "dev-admin@stellar-privacy.local",
+          permissions: ["admin:access"],
+          rateLimitTier: "enterprise" as const,
+          sessionId: "dev-admin-session",
+        };
+        return next();
+      }
+    }
+  }
+
+  // Standard authentication — sends 401 on failure and never calls next()
+  stellarAuth.authenticate(req as any, res, () => {
+    // Role-based access: only users with admin:access permission
+    if (!(req as any).user?.permissions?.includes("admin:access")) {
+      res.status(403).json({ error: "Admin access required" });
+      return;
+    }
+    next();
+  });
+};
+
+const router = express.Router();
+
+// GET /api/v1/admin/rate-limit/metrics — admin only
+router.get("/rate-limit/metrics", adminAuth, (_req, res) => {
+  const metrics = rateLimitMonitor.getMetricsSummary();
+  res.json({
+    metrics,
+    timestamp: new Date().toISOString(),
+    environment: process.env.NODE_ENV || "development",
+  });
+});
+
+// GET /api/v1/admin/rate-limit/config — admin only
+router.get("/rate-limit/config", adminAuth, (_req, res) => {
+  res.json({
+    config: {
+      standard: {
+        windowMs: 15 * 60 * 1000,
+        basic: { maxRequests: 100 },
+        premium: { maxRequests: 500 },
+        enterprise: { maxRequests: 2000 },
+      },
+      enhanced: {
+        collisionDetection: true,
+        burstProtection: true,
+        adaptiveLimiting: true,
+        alerting: true,
+      },
+      monitoring: {
+        enabled: true,
+        interval: 30000,
+        retention: 24 * 60 * 60 * 1000,
+      },
+    },
+    timestamp: new Date().toISOString(),
+  });
+});
+
+export { router as adminRoutes };


### PR DESCRIPTION
## Summary

Fixes #369 - [MEDIUM] Unauthenticated Metrics Endpoint Exposes System Internals in Development Mode

## Changes

### Problem
Two admin endpoints (`/api/v1/admin/rate-limit/metrics` and `/api/v1/admin/rate-limit/config`) exposed detailed operational metrics. In development mode, the auth check was skipped entirely via `NODE_ENV !== 'production'` bypass, allowing attackers to map the API's rate limiting landscape and calibrate attacks.

### Solution
- **Removed the `NODE_ENV !== 'production'` bypass** — endpoints now require authentication in ALL environments
- **Applied `stellarAuth.authenticate` middleware** to the admin routes
- **Implemented role-based access control** — only users with `admin:access` permission can access these endpoints (403 for non-admin users)
- **Added `DEV_ADMIN_TOKEN` env var** — configurable development admin token for local convenience (never hardcoded, only in non-production)
- **Extracted admin routes** into `backend/src/routes/admin.ts` for clean code organization and testability

### Files Changed
| File | Change |
|------|--------|
| `backend/src/index.ts` | Replaced inline admin endpoints with `app.use("/api/v1/admin", adminRoutes)` |
| `backend/src/routes/admin.ts` | **New** — Admin routes with `adminAuth` middleware |
| `backend/src/config/env.ts` | Added `DEV_ADMIN_TOKEN` to env schema |
| `backend/src/__tests__/admin-rate-limit.test.ts` | **New** — 14 comprehensive tests |

### Test Coverage
- ✅ Unauthenticated → 401 in ALL environments (dev, test, production)
- ✅ Non-admin user → 403 in ALL environments
- ✅ Admin user → 200 with full metrics/config
- ✅ Dev admin token → 200 in non-production
- ✅ Invalid dev token → 401
- ✅ Dev token rejection in production → 401

### Acceptance Criteria Checklist
- [x] Remove `NODE_ENV !== 'production'` bypass — auth required in ALL environments
- [x] Apply `stellarAuth.authenticate` to admin routes
- [x] Role-based access: only admin users can access
- [x] Configurable `DEV_ADMIN_TOKEN` via env var
- [x] Tests: unauthenticated → 401, non-admin → 403, admin → 200
closes #369